### PR TITLE
feat(android): migrate to compilerOptions DSL for Kotlin 2.3+ compatibility

### DIFF
--- a/packages/app_intents/android/build.gradle.kts
+++ b/packages/app_intents/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -12,11 +14,13 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     defaultConfig {
         minSdk = 21
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }


### PR DESCRIPTION
This PR migrates the app_intents Android build configuration from the deprecated kotlinOptions DSL to the modern compilerOptions DSL. 

In recent versions of the Kotlin Gradle Plugin (specifically 2.3.0 and above, paired with AGP 9.1.0+), the kotlinOptions block in build.gradle.kts has transitioned from being deprecated to causing hard build failures (Script compilation errors) in some configurations.

Migrating to compilerOptions ensures compatibility with the latest Android build toolchains and follows official Kotlin migration guidelines.