### PR TITLE
feat: Upgrade AppFunctions to 1.0.0-alpha09

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ docs/
 | Intent Execution (Android) | **MethodChannel** (in-process, no URL scheme needed) |
 | Deep Linking | **app_links** package |
 | Android Minimum | **API 36** (Android 16, for AppFunctions) |
-| Android AppFunctions | **Jetpack `androidx.appfunctions` 1.0.0-alpha07** |
+| Android AppFunctions | **Jetpack `androidx.appfunctions` 1.0.0-alpha09** |
 | Cross-Process Storage (iOS) | **App Group UserDefaults** (explicit configuration required) |
 
 ## Implementation Status
@@ -104,7 +104,7 @@ docs/
 
 - Android AppFunctions Integration:
   - `KotlinGenerator`: Generates Android 16+ AppFunctions Kotlin code
-    - `@AppFunction(isDescribedByKdoc = true)` annotated methods
+    - `@AppFunction(isDescribedByKDoc = true)` annotated methods
     - `@AppFunctionSerializable` data classes for entities
     - `AppFunctionsBridge` singleton for MethodChannel communication
     - `GeneratedAppFunctions` class with no-arg constructor (KSP requirement)
@@ -198,7 +198,7 @@ Options:
 - `@AppFunction` is in `androidx.appfunctions.service.AppFunction` (NOT `androidx.appfunctions`)
 - `@AppFunctionSerializable` is in `androidx.appfunctions.AppFunctionSerializable`
 - `AppFunctionContext` is in `androidx.appfunctions.AppFunctionContext`
-- Parameter name is `isDescribedByKdoc` (lowercase 'd'), NOT `isDescribedByKDoc`
+- Parameter name is `isDescribedByKDoc` (uppercase 'D'); alpha07 and earlier used the lowercase `isDescribedByKdoc`
 - KSP compiler cannot handle `Map<String, Any?>` as `@AppFunction` return type — use `String` (JSON)
 - KSP version format: `{kotlin-version}-{ksp-version}` (e.g., `2.2.20-2.0.4`)
 - Three Jetpack artifacts: `appfunctions`, `appfunctions-service`, `appfunctions-compiler`
@@ -425,16 +425,24 @@ if #available(iOS 17.0, *) {
 6. Set iOS deployment target to 17.0 in Podfile
 
 ### Android App Integration Steps
-1. Add KSP plugin to `android/settings.gradle.kts`:
+1. Use AGP 9.1.0+ / Gradle 9.3.1+ (required by `appfunctions:1.0.0-alpha09`)
+2. Add KSP plugin to `android/settings.gradle.kts`:
    ```kotlin
+   id("com.android.application") version "9.1.1" apply false
+   id("org.jetbrains.kotlin.android") version "2.2.20" apply false
    id("com.google.devtools.ksp") version "2.2.20-2.0.4" apply false
    ```
-2. Configure `android/app/build.gradle.kts`:
-   - Apply KSP plugin, set `compileSdk = 36`, `minSdk = 36`
+3. Add the following to `android/gradle.properties` (AGP 9 compatibility shims for Flutter + KSP):
+   ```properties
+   android.newDsl=false
+   android.builtInKotlin=false
+   ```
+4. Configure `android/app/build.gradle.kts`:
+   - Apply `kotlin-android` and KSP plugins, set `compileSdk = 37`, `targetSdk = 37`, `minSdk = 36`
    - Add AppFunctions dependencies (`appfunctions`, `appfunctions-service`, `appfunctions-compiler`)
    - Add KSP arg: `ksp { arg("appfunctions:aggregateAppFunctions", "true") }`
-3. Run `make kotlin-gen` to generate Kotlin code
-4. Wire AppFunctionsBridge in MainActivity:
+5. Run `make kotlin-gen` to generate Kotlin code
+6. Wire AppFunctionsBridge in MainActivity:
 ```kotlin
 import com.example.app_intents.AppIntentsPlugin
 import com.example.app.generated.AppFunctionsBridge
@@ -449,7 +457,7 @@ class MainActivity : FlutterActivity() {
     }
 }
 ```
-5. Register AppFunctionService in `AndroidManifest.xml`
+7. Register AppFunctionService in `AndroidManifest.xml`
 
 ## Development Commands
 
@@ -635,7 +643,7 @@ import androidx.appfunctions.AppFunctionSerializable
 import androidx.appfunctions.service.AppFunction
 import io.flutter.plugin.common.MethodChannel
 
-@AppFunctionSerializable(isDescribedByKdoc = true)
+@AppFunctionSerializable(isDescribedByKDoc = true)
 data class TaskEntitySpec(
     val id: String,
     val title: String,
@@ -652,7 +660,7 @@ class GeneratedAppFunctions {
      * @param appFunctionContext The context for this app function execution.
      * @param title The title of the task
      */
-    @AppFunction(isDescribedByKdoc = true)
+    @AppFunction(isDescribedByKDoc = true)
     suspend fun createTask(
         appFunctionContext: AppFunctionContext,
         title: String

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.example.app"
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         applicationId = "com.example.app"
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
@@ -42,9 +42,9 @@ ksp {
 }
 
 dependencies {
-    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha07")
-    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha07")
-    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha07")
+    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha09")
+    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha09")
+    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha09")
 }
 
 flutter {

--- a/app/android/app/src/main/kotlin/com/example/app/generated/GeneratedAppFunctions.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/generated/GeneratedAppFunctions.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.withContext
  * @param title The display title.
  * @param description The subtitle or description.
  */
-@AppFunctionSerializable(isDescribedByKdoc = true)
+@AppFunctionSerializable(isDescribedByKDoc = true)
 data class TaskEntitySpec(
     val id: String,
     val title: String,
@@ -89,7 +89,7 @@ class GeneratedAppFunctions {
      * @param appFunctionContext The context for this app function execution.
      * @param task The task to complete
      */
-    @AppFunction(isDescribedByKdoc = true)
+    @AppFunction(isDescribedByKDoc = true)
     suspend fun completeTask(
         appFunctionContext: AppFunctionContext,
         task: String
@@ -107,7 +107,7 @@ class GeneratedAppFunctions {
      * @param description Optional description for the task (optional)
      * @param dueDate When the task is due (optional)
      */
-    @AppFunction(isDescribedByKdoc = true)
+    @AppFunction(isDescribedByKDoc = true)
     suspend fun createTask(
         appFunctionContext: AppFunctionContext,
         title: String,
@@ -128,15 +128,15 @@ class GeneratedAppFunctions {
      * @param title The title of the task
      * @param image An image to attach to the task (optional)
      */
-    @AppFunction(isDescribedByKdoc = true)
+    @AppFunction(isDescribedByKDoc = true)
     suspend fun createTaskWithImage(
         appFunctionContext: AppFunctionContext,
         title: String,
-        image: IntentFile? = null
+        image: String? = null
     ): String {
         val params = mutableMapOf<String, Any?>()
         params["title"] = title
-        if (image != null) params["image"] = image
+        if (image != null) params["image"] = mapOf("path" to image, "mimeType" to java.net.URLConnection.guessContentTypeFromName(image), "filename" to java.io.File(image).name)
         return bridge.executeIntent("com.example.taskapp.createTaskWithImage", params)
     }
 }

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+android.newDsl=false
+android.builtInKotlin=false

--- a/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
+    id("com.android.application") version "9.1.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
     id("com.google.devtools.ksp") version "2.2.20-2.0.4" apply false
 }

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - app_intents (0.7.5):
+  - app_intents (0.7.8):
     - Flutter
   - Flutter (1.0.0)
 
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  app_intents: e1c16ea8d1a87b224913f87ceecd0790d280530d
+  app_intents: 882a5f43aa82bf06ae6dbcbe6f2d3beeaaf36934
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
 
 PODFILE CHECKSUM: 68a0fe41997147e5d043c7ed50614ab4a3969700

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -23,21 +23,21 @@ packages:
       path: "../packages/app_intents"
       relative: true
     source: path
-    version: "0.7.5"
+    version: "0.7.8"
   app_intents_annotations:
     dependency: "direct main"
     description:
       path: "../packages/app_intents_annotations"
       relative: true
     source: path
-    version: "0.7.5"
+    version: "0.7.8"
   app_intents_codegen:
     dependency: "direct dev"
     description:
       path: "../packages/app_intents_codegen"
       relative: true
     source: path
-    version: "0.7.5"
+    version: "0.7.8"
   app_links:
     dependency: "direct main"
     description:

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -357,7 +357,7 @@ struct AppShortcuts: AppShortcutsProvider {
 |------|------|
 | **Android最小バージョン** | API 36 (Android 16) |
 | **Kotlin** | 2.2+ |
-| **Jetpack AppFunctions** | 1.0.0-alpha07 |
+| **Jetpack AppFunctions** | 1.0.0-alpha09 |
 
 ### 設計決定事項
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -358,7 +358,7 @@ struct AppShortcuts: AppShortcutsProvider {
 |------|-------------|
 | **Minimum Android** | API 36 (Android 16) |
 | **Kotlin** | 2.2+ |
-| **Jetpack AppFunctions** | 1.0.0-alpha07 |
+| **Jetpack AppFunctions** | 1.0.0-alpha09 |
 
 ### Design Decisions
 

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -29,14 +29,15 @@ platform :ios, '17.0'
 
 #### Android
 
-`android/app/build.gradle.kts`で`compileSdk`、`minSdk`、`targetSdk`を36に設定（AppFunctionsはAndroid 16が必要）:
+`appfunctions:1.0.0-alpha09` は **Android Gradle Plugin 9.1.0+**、**Gradle 9.3.1+**、**compileSdk 37** を必要とします。
+`android/app/build.gradle.kts` を更新します（`minSdk = 36` は AppFunctions が Android 16 を必要とするため）:
 
 ```kotlin
 android {
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
     }
 }
 ```
@@ -45,16 +46,21 @@ KSPとAppFunctionsの依存関係を追加:
 
 ```kotlin
 // android/settings.gradle.kts
+id("com.android.application") version "9.1.1" apply false
+id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 id("com.google.devtools.ksp") version "2.2.20-2.0.4" apply false
 
 // android/app/build.gradle.kts
 plugins {
+    id("com.android.application")
+    id("kotlin-android")
     id("com.google.devtools.ksp")
+    id("dev.flutter.flutter-gradle-plugin")
 }
 dependencies {
-    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha07")
-    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha07")
-    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha07")
+    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha09")
+    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha09")
+    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha09")
 }
 
 ksp {
@@ -62,7 +68,22 @@ ksp {
 }
 ```
 
-> **Note**: AppFunctionsは Android 16（API 36）以上が必須です。
+`android/gradle.properties` に AGP 9 互換性のための shim を追加します:
+
+```properties
+# Flutter Gradle plugin はまだ AGP 9 の new DSL をサポートしていないため legacy DSL を使う
+android.newDsl=false
+# KSP は AGP 9 の built-in Kotlin と非互換のため kotlin-android プラグインを維持する
+android.builtInKotlin=false
+```
+
+`android/gradle/wrapper/gradle-wrapper.properties` の Gradle wrapper を 9.3.1+ に更新します:
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+```
+
+> **Note**: AppFunctionsは Android 16（API 36）以上が必須です。`compileSdk 37` の要求は `appfunctions:1.0.0-alpha09` の AAR メタデータに由来します。
 
 ### 3. iOSネイティブ設定 (AppIntentsBridge)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,14 +29,15 @@ platform :ios, '17.0'
 
 #### Android
 
-Set `compileSdk`, `minSdk`, and `targetSdk` to 36 in `android/app/build.gradle.kts` (AppFunctions requires Android 16):
+`appfunctions:1.0.0-alpha09` requires **Android Gradle Plugin 9.1.0+**, **Gradle 9.3.1+**, and **compileSdk 37**.
+Update `android/app/build.gradle.kts` (`minSdk = 36` because AppFunctions requires Android 16):
 
 ```kotlin
 android {
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
     }
 }
 ```
@@ -45,16 +46,21 @@ Add KSP and AppFunctions dependencies:
 
 ```kotlin
 // android/settings.gradle.kts
+id("com.android.application") version "9.1.1" apply false
+id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 id("com.google.devtools.ksp") version "2.2.20-2.0.4" apply false
 
 // android/app/build.gradle.kts
 plugins {
+    id("com.android.application")
+    id("kotlin-android")
     id("com.google.devtools.ksp")
+    id("dev.flutter.flutter-gradle-plugin")
 }
 dependencies {
-    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha07")
-    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha07")
-    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha07")
+    implementation("androidx.appfunctions:appfunctions:1.0.0-alpha09")
+    implementation("androidx.appfunctions:appfunctions-service:1.0.0-alpha09")
+    ksp("androidx.appfunctions:appfunctions-compiler:1.0.0-alpha09")
 }
 
 ksp {
@@ -62,7 +68,22 @@ ksp {
 }
 ```
 
-> **Note**: AppFunctions requires Android 16 (API 36) or later.
+Add the following AGP 9 compatibility shims to `android/gradle.properties`:
+
+```properties
+# Flutter Gradle plugin does not yet support the new AGP 9 DSL — keep legacy DSL.
+android.newDsl=false
+# KSP is incompatible with AGP 9's built-in Kotlin — keep the kotlin-android plugin.
+android.builtInKotlin=false
+```
+
+Update the Gradle wrapper to 9.3.1+ in `android/gradle/wrapper/gradle-wrapper.properties`:
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+```
+
+> **Note**: AppFunctions requires Android 16 (API 36) or later. The `compileSdk = 37` requirement comes from the `appfunctions:1.0.0-alpha09` AAR metadata.
 
 ### 3. iOS Native Setup (AppIntentsBridge)
 

--- a/packages/app_intents_codegen/lib/src/generator/kotlin_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/kotlin_generator.dart
@@ -193,7 +193,7 @@ class KotlinGenerator {
     buffer.writeln('$prefix */');
 
     // @AppFunction annotation
-    buffer.writeln('$prefix@AppFunction(isDescribedByKdoc = true)');
+    buffer.writeln('$prefix@AppFunction(isDescribedByKDoc = true)');
 
     // Function signature
     final paramStrings = <String>[
@@ -276,7 +276,7 @@ class KotlinGenerator {
     buffer.writeln(' */');
 
     // Annotation
-    buffer.writeln('@AppFunctionSerializable(isDescribedByKdoc = true)');
+    buffer.writeln('@AppFunctionSerializable(isDescribedByKDoc = true)');
 
     // Data class
     buffer.writeln('data class ${info.className}(');

--- a/packages/app_intents_codegen/test/generator/kotlin_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/kotlin_generator_test.dart
@@ -69,7 +69,7 @@ void main() {
         expect(result, contains('import androidx.appfunctions.service.AppFunction'));
         expect(
             result, contains('import androidx.appfunctions.AppFunctionContext'));
-        expect(result, contains('@AppFunction(isDescribedByKdoc = true)'));
+        expect(result, contains('@AppFunction(isDescribedByKDoc = true)'));
         expect(result, contains('suspend fun greet('));
         expect(result, contains('appFunctionContext: AppFunctionContext'));
         expect(result, contains('): String {'));
@@ -446,7 +446,7 @@ void main() {
         expect(result, contains(
             'import androidx.appfunctions.AppFunctionSerializable'));
         expect(result, contains(
-            '@AppFunctionSerializable(isDescribedByKdoc = true)'));
+            '@AppFunctionSerializable(isDescribedByKDoc = true)'));
         expect(result, contains('data class TaskEntity('));
         expect(result, contains('val id: String'));
         expect(result, contains('val title: String'));


### PR DESCRIPTION
## Summary

Bump `androidx.appfunctions` from `1.0.0-alpha07` to `1.0.0-alpha09`. alpha09's AAR metadata requires AGP 9.1.0+, Gradle 9.3.1+, and compileSdk 37, so the example app's Android toolchain is upgraded accordingly. The `@AppFunction` / `@AppFunctionSerializable` parameter `isDescribedByKdoc` was renamed to `isDescribedByKDoc` in alpha08, so the KotlinGenerator emits the new casing.

### Background: issue jt-momentia/habee-app#1551

That issue reports AppFunctions alpha07 pulling in `androidx.glance:glance-appwidget:1.3.0-alpha01` / `androidx.compose.remote:remote-creation-android:1.0.0-alpha11` which then require AGP 9.1.0+ / compileSdk 37+. I confirmed with `./gradlew :app:dependencies` that **this repo never pulls those transitive deps in either alpha07 or alpha09** — alpha07 with AGP 8.11.1 was fine here. However, **alpha09 itself records `compileSdk 37` and `minAgpVersion 9.1.0` in its AAR metadata**, so the upgrade still requires the same Android toolchain bump.

## Changes

### Toolchain
- `app/android/settings.gradle.kts`: AGP `8.11.1` → `9.1.1`
- `app/android/gradle/wrapper/gradle-wrapper.properties`: Gradle `8.14` → `9.3.1`
- `app/android/app/build.gradle.kts`: `compileSdk` / `targetSdk` `36` → `37`
- `app/android/gradle.properties`:
  - `android.newDsl=false` — Flutter Gradle plugin does not support AGP 9's new DSL yet (Flutter issue flutter/flutter#184838 already defaults the legacy DSL, but we set it explicitly)
  - `android.builtInKotlin=false` — KSP is not compatible with AGP 9's built-in Kotlin; keep the `kotlin-android` plugin

### AppFunctions / codegen
- Bump `appfunctions`, `appfunctions-service`, `appfunctions-compiler` to `1.0.0-alpha09`
- `kotlin_generator.dart`: emit `isDescribedByKDoc` (uppercase D); regenerate `GeneratedAppFunctions.kt`
- `kotlin_generator_test.dart`: update assertions

### Docs
- `CLAUDE.md`, `docs/usage.md`, `docs/usage.ja.md`: document the new version, Android toolchain requirements, and the two `gradle.properties` shims

## Test plan
- [x] `dart test packages/app_intents_codegen` — all 230 tests pass
- [x] `make kotlin-gen` — regenerates with `isDescribedByKDoc`
- [x] `flutter build apk --debug` — builds successfully on AGP 9.1.1 + Gradle 9.3.1 + compileSdk 37
- [x] `flutter build ios --debug --no-codesign` — iOS unaffected, builds successfully
- [ ] Smoke test on a physical Android 16 device once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)