### PR TITLE
fix: Add @AppShortcutsBuilder annotation to generated AppShortcuts

### DIFF
--- a/app/ios/Runner/GeneratedIntents/GeneratedAppIntents.swift
+++ b/app/ios/Runner/GeneratedIntents/GeneratedAppIntents.swift
@@ -203,6 +203,7 @@ struct TaskEntitySpecQuery: EntityQuery {
 
 @available(iOS 17.0, *)
 struct AppShortcuts: AppShortcutsProvider {
+    @AppShortcutsBuilder
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
             intent: CreateTaskIntentSpec(),

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -814,7 +814,7 @@ class SwiftGenerator {
     // Availability and struct declaration
     buffer.writeln('@available(iOS 17.0, *)');
     buffer.writeln('struct AppShortcuts: AppShortcutsProvider {');
-    buffer.writeln('${_indent}@AppShortcutsBuilder');
+    buffer.writeln('$_indent@AppShortcutsBuilder');
     buffer.writeln('${_indent}static var appShortcuts: [AppShortcut] {');
 
     for (final shortcut in shortcuts) {

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -814,6 +814,7 @@ class SwiftGenerator {
     // Availability and struct declaration
     buffer.writeln('@available(iOS 17.0, *)');
     buffer.writeln('struct AppShortcuts: AppShortcutsProvider {');
+    buffer.writeln('${_indent}@AppShortcutsBuilder');
     buffer.writeln('${_indent}static var appShortcuts: [AppShortcut] {');
 
     for (final shortcut in shortcuts) {

--- a/packages/app_intents_codegen/test/generator/swift_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_test.dart
@@ -1612,6 +1612,7 @@ void main() {
         expect(result, contains('import AppIntents'));
         expect(result, contains('@available(iOS 17.0, *)'));
         expect(result, contains('struct AppShortcuts: AppShortcutsProvider'));
+        expect(result, contains('@AppShortcutsBuilder'));
         expect(result, contains('static var appShortcuts: [AppShortcut]'));
         expect(result, contains('AppShortcut('));
         expect(result, contains('intent: CreateTaskIntent()'));


### PR DESCRIPTION
## Summary
- Emit `@AppShortcutsBuilder` on the generated `appShortcuts` static property to match Apple's documented `AppShortcutsProvider` protocol requirement.
- Update the example app's generated Swift to reflect the new output.
- Add a regression test ensuring the annotation is present in generated code.

Closes #25

## Why
Without `@AppShortcutsBuilder`, the multiple `AppShortcut(...)` expressions stacked in the property body rely on implicit result builder behavior. Apple's documentation explicitly declares the protocol requirement with the attribute, and future Xcode/iOS releases may tighten result builder enforcement (similar to past `@ViewBuilder` tightening), potentially refusing to compile or silently dropping all but the last `AppShortcut`.

## Test plan
- [x] `dart test` in `packages/app_intents_codegen` — all 230 tests pass
- [x] Regenerated example app's `GeneratedAppIntents.swift` — `@AppShortcutsBuilder` now appears before `static var appShortcuts`
- [ ] Build verified on iOS Simulator (Xcode 26.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)