### PR TITLE
feat: Add App Group cache fallback to EntityQuery codegen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ docs/
 - `app_intents_annotations`: All annotations defined
   - `@IntentSpec` (with `urlScheme`/`urlAction`, `resultDialogTemplate`, `parameterSummary`)
   - `@IntentParam` (with `entityType` for entity picker, `enumType` for AppEnum parameters)
-  - `@EntitySpec`, `@EntityId`, `@EntityTitle`, `@EntitySubtitle`, `@EntityImage`, `@EntityDefaultQuery`
+  - `@EntitySpec` (with `persistedCacheKey` for App Group cold-start fallback), `@EntityId`, `@EntityTitle`, `@EntitySubtitle`, `@EntityImage`, `@EntityDefaultQuery`
   - `@EnumSpec`, `@EnumCaseDisplay` for AppEnum support
   - `@AppShortcut`, `@AppShortcutsProvider`
 - `app_intents`: Platform Interface extended
@@ -66,6 +66,7 @@ docs/
     - AppShortcut phrase `{paramName}` → `\(\.$paramName)` conversion
     - Proper error handling (`throw` instead of silent `return .result()`)
     - FlutterBridge-backed EntityQuery with `entities(for:)` and `suggestedEntities()`
+    - App Group UserDefaults fallback in EntityQuery (when `persistedCacheKey` set, or `enumerable`/`indexed` provides a default key) for cold-start resilience
   - `DartGenerator`: Generates `initializeXxxAppIntents()` as part files
     - Generates type-safe `XxxParams` classes with `fromMap()` and `fromQueryParameters()` factories
     - Always registers both `registerEntityQueryHandler` and `registerSuggestedEntitiesHandler`
@@ -131,6 +132,14 @@ docs/
   - `Bundle.main.bundleIdentifier` differs between main app and extensions → cache key mismatch
   - Solution: Call `AppIntentsPlugin.configure(appGroupIdentifier:)` in both AppDelegate and generated Swift code
   - Dart side: Call `AppIntents().configureStorage(appGroupIdentifier:)` before cache operations
+
+- **EntityQuery Cold-Start Fallback (`persistedCacheKey`)**: When the host app is killed by iOS and Siri/Shortcuts triggers an EntityQuery, the Flutter engine may not finish initializing within `FlutterBridge`'s 5-second timeout, causing `entityQueryNotConfigured` errors. To handle this:
+  - Set `@EntitySpec(persistedCacheKey: 'your.cache.key')` to make the generated `EntityQuery` read the entity list from App Group UserDefaults before waiting on the Flutter executor.
+  - When `persistedCacheKey` is not set but `enumerable: true` or `indexed: true`, codegen falls back to the default key `app_intents.entities.<identifier>`. The Dart side must use that exact string with `setCachedValue`.
+  - **Key namespacing**: `persistedCacheKey` is the value you pass to `AppIntents().setCachedValue(key, value)` — not the raw `UserDefaults` key. The plugin namespaces it under `app_intents.<bundleId-or-storageId>.cache.` internally.
+  - **Payload shape**: Pass either a JSON-encoded string of `List<Map<String, dynamic>>` or a pre-decoded `List<Map>`. Each map's keys must match the entity's `@EntityId`/`@EntityTitle`/`@EntitySubtitle`/`@EntityImage` field names (not the underlying model's field names — they often differ). Maps missing id or title are silently dropped.
+  - **App Group prerequisite**: Same as cache-mode intents — call `AppIntentsPlugin.configure(appGroupIdentifier:)` in AppDelegate and `AppIntents().configureStorage(appGroupIdentifier:)` in Dart. Without this, the EntityQuery extension process and main app cannot share storage and the fallback won't help.
+  - **Example**: `app/lib/repositories/task_repository.dart` writes both the full task storage and the entity-shaped projection under `com.example.taskapp.cache.tasks` every time tasks change.
 
 ### Future Migration
 - **`@Property` wrapper**: Expose entity properties to system (Spotlight, etc.)

--- a/app/ios/Runner/GeneratedIntents/GeneratedAppIntents.swift
+++ b/app/ios/Runner/GeneratedIntents/GeneratedAppIntents.swift
@@ -169,7 +169,16 @@ struct TaskEntitySpec: AppEntity {
 
 @available(iOS 17.0, *)
 struct TaskEntitySpecQuery: EntityQuery {
+    /// App Group UserDefaults key written from Dart via setCachedValue.
+    static let cacheKey = "com.example.taskapp.cache.tasks"
+
     func entities(for identifiers: [String]) async throws -> [TaskEntitySpec] {
+        if let cached = Self._readCachedEntities() {
+            let filtered = cached.filter { identifiers.contains($0.id) }
+            if !filtered.isEmpty {
+                return filtered
+            }
+        }
         let results = try await FlutterBridge.shared.queryEntities(
             entityIdentifier: "com.example.taskapp.TaskEntity",
             identifiers: identifiers
@@ -186,6 +195,9 @@ struct TaskEntitySpecQuery: EntityQuery {
     }
 
     func suggestedEntities() async throws -> [TaskEntitySpec] {
+        if let cached = Self._readCachedEntities(), !cached.isEmpty {
+            return cached
+        }
         let results = try await FlutterBridge.shared.suggestedEntities(
             entityIdentifier: "com.example.taskapp.TaskEntity"
         )
@@ -198,6 +210,34 @@ struct TaskEntitySpecQuery: EntityQuery {
             let iconName = dict["iconName"] as? String
             return TaskEntitySpec(id: id, title: title, description: description, iconName: iconName)
         }
+    }
+
+    /// Reads cached entities from App Group UserDefaults.
+    /// Accepts either a JSON string payload or a pre-decoded array of maps.
+    private static func _readCachedEntities() -> [TaskEntitySpec]? {
+        guard let raw = AppIntentsPlugin.getCached(forKey: cacheKey) else {
+            return nil
+        }
+        let dicts: [[String: Any]]
+        if let array = raw as? [[String: Any]] {
+            dicts = array
+        } else if let jsonString = raw as? String,
+                let data = jsonString.data(using: .utf8),
+                let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+            dicts = parsed
+        } else {
+            return nil
+        }
+        let entities: [TaskEntitySpec] = dicts.compactMap { dict in
+            guard let id = dict["id"] as? String,
+                let title = dict["title"] as? String else {
+                return nil
+            }
+            let description = dict["description"] as? String
+            let iconName = dict["iconName"] as? String
+            return TaskEntitySpec(id: id, title: title, description: description, iconName: iconName)
+        }
+        return entities
     }
 }
 

--- a/app/lib/entities/task_entity.dart
+++ b/app/lib/entities/task_entity.dart
@@ -15,6 +15,7 @@ part 'task_entity.intent.dart';
   title: 'Task',
   pluralTitle: 'Tasks',
   description: 'A task in your task list',
+  persistedCacheKey: 'com.example.taskapp.cache.tasks',
 )
 class TaskEntitySpec extends EntitySpecBase<Task> {
   @EntityId()

--- a/app/lib/repositories/task_repository.dart
+++ b/app/lib/repositories/task_repository.dart
@@ -18,6 +18,13 @@ class TaskRepository {
 
   static const _storageKey = 'tasks';
 
+  /// Cache key that mirrors the entity list for EntityQuery cold-start fallback.
+  ///
+  /// Must match `TaskEntitySpec`'s `persistedCacheKey`. Generated Swift reads
+  /// from this key (via `AppIntentsPlugin.getCached`) when Siri/Shortcuts
+  /// fires an EntityQuery before the Flutter engine has finished initializing.
+  static const _entityCacheKey = 'com.example.taskapp.cache.tasks';
+
   /// In-memory cache backed by App Group UserDefaults.
   final Map<String, Task> _tasks = {};
 
@@ -53,9 +60,25 @@ class TaskRepository {
   }
 
   /// Persists current tasks to App Group UserDefaults.
+  ///
+  /// Writes both the full task list (`_storageKey`) and the
+  /// entity-shaped projection used by the EntityQuery cold-start fallback
+  /// (`_entityCacheKey`). Field names in the entity projection must match
+  /// `TaskEntitySpec`'s `@EntityId`/`@EntityTitle`/etc. annotations.
   Future<void> _saveToStorage() async {
     final json = jsonEncode(_tasks.values.map((t) => t.toJson()).toList());
     await AppIntents().setCachedValue(_storageKey, json);
+
+    final entityJson = jsonEncode(
+      _tasks.values
+          .map((t) => {
+                'id': t.id,
+                'title': t.title,
+                'description': t.description,
+              })
+          .toList(),
+    );
+    await AppIntents().setCachedValue(_entityCacheKey, entityJson);
   }
 
   /// Gets all tasks.

--- a/packages/app_intents_annotations/CHANGELOG.md
+++ b/packages/app_intents_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `@EntitySpec.persistedCacheKey` for EntityQuery cold-start fallback (#26)
+
 ## 0.8.0
 
 - No API changes; version bump to align with the AppFunctions alpha09 upgrade in `app_intents_codegen` (#23)

--- a/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
@@ -28,6 +28,41 @@ class EntitySpec {
   /// Generates an extension with `allEntities()` that delegates to `suggestedEntities()`.
   final bool enumerable;
 
+  /// Cache key used by the generated Swift `EntityQuery` to look up the entity
+  /// list before waiting on the Flutter executor.
+  ///
+  /// This is the key passed to `AppIntents().setCachedValue(key, value)` from
+  /// Dart — not the raw `UserDefaults` key (the plugin internally namespaces
+  /// it under `app_intents.<bundleId>.cache.`).
+  ///
+  /// ## Payload shape
+  /// The value written from Dart must be either:
+  /// - A `String` containing JSON of `List<Map<String, dynamic>>`, or
+  /// - A pre-decoded `List<Map<String, dynamic>>` (passes through the
+  ///   MethodChannel as `[[String: Any]]` on the Swift side).
+  ///
+  /// Each map must contain string-typed keys matching the entity's annotated
+  /// field names (`@EntityId`, `@EntityTitle`, `@EntitySubtitle`,
+  /// `@EntityImage`). Maps missing the id or title fields are silently
+  /// dropped. Use entity field names, **not** the underlying model's field
+  /// names — they often differ.
+  ///
+  /// ## Cold-start motivation
+  /// When iOS kills the host app and Siri/Shortcuts fires an EntityQuery,
+  /// `FlutterBridge` waits up to 5 seconds for the Flutter executor to be
+  /// registered. On a real cold start, that timeout can be exhausted before
+  /// the engine is ready, surfacing as a generic "internal error". The cache
+  /// lookup runs synchronously and short-circuits this path when the data is
+  /// already in App Group UserDefaults.
+  ///
+  /// ## Default key
+  /// When unset but [enumerable] or [indexed] is `true`, codegen uses
+  /// `app_intents.entities.<identifier>` as the default cache key. The Dart
+  /// side must call `setCachedValue` with that exact string. When unset and
+  /// neither flag is true, no fallback is generated and the Flutter executor
+  /// must be available.
+  final String? persistedCacheKey;
+
   const EntitySpec({
     required this.identifier,
     required this.title,
@@ -36,5 +71,6 @@ class EntitySpec {
     this.displayImageName,
     this.indexed = false,
     this.enumerable = false,
+    this.persistedCacheKey,
   });
 }

--- a/packages/app_intents_codegen/CHANGELOG.md
+++ b/packages/app_intents_codegen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Generated Swift `EntityQuery` now reads cached entities from App Group `UserDefaults` before waiting on the Flutter executor, mitigating the cold-start `entityQueryNotConfigured` error when iOS has killed the host app (#26)
+- `SwiftGenerator` emits the new App Group fallback path when `@EntitySpec(persistedCacheKey: ...)` is set, or when `enumerable: true` / `indexed: true` provides a default key `app_intents.entities.<identifier>`
+- Generated Swift `AppShortcuts` struct now uses the `@AppShortcutsBuilder` result builder annotation per Apple's `AppShortcutsProvider` protocol requirement (#25)
+
 ## 0.8.0
 
 - Upgrade `androidx.appfunctions` from `1.0.0-alpha07` to `1.0.0-alpha09` in the example app (#23)

--- a/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
@@ -60,6 +60,8 @@ class EntityAnalyzer {
     final indexed = annotation.getField('indexed')?.toBoolValue() ?? false;
     final enumerable =
         annotation.getField('enumerable')?.toBoolValue() ?? false;
+    final persistedCacheKey =
+        annotation.getField('persistedCacheKey')?.toStringValue();
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -94,6 +96,7 @@ class EntityAnalyzer {
       displayImageName: displayImageName,
       indexed: indexed,
       enumerable: enumerable,
+      persistedCacheKey: persistedCacheKey,
     );
   }
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -457,6 +457,9 @@ class SwiftGenerator {
     if (info.indexed) {
       buffer.writeln('import CoreSpotlight');
     }
+    if (info.effectiveCacheKey != null) {
+      buffer.writeln('import app_intents');
+    }
     buffer.writeln();
 
     // Entity body
@@ -578,11 +581,31 @@ class SwiftGenerator {
         .where((p) => p.role == EntityPropertyRole.image)
         .firstOrNull;
 
+    final cacheKey = info.effectiveCacheKey;
+
     buffer.writeln('@available(iOS 17.0, *)');
     buffer.writeln('struct ${info.className}Query: EntityQuery {');
 
+    if (cacheKey != null) {
+      buffer.writeln(
+          '$_indent/// App Group UserDefaults key written from Dart via setCachedValue.');
+      buffer.writeln('${_indent}static let cacheKey = "$cacheKey"');
+      buffer.writeln();
+    }
+
     // entities(for:) method
     buffer.writeln('${_indent}func entities(for identifiers: [String]) async throws -> [${info.className}] {');
+    if (cacheKey != null) {
+      final idField = idProp?.fieldName ?? 'id';
+      buffer.writeln(
+          '$_indent${_indent}if let cached = Self._readCachedEntities() {');
+      buffer.writeln(
+          '$_indent$_indent${_indent}let filtered = cached.filter { identifiers.contains(\$0.$idField) }');
+      buffer.writeln('$_indent$_indent${_indent}if !filtered.isEmpty {');
+      buffer.writeln('$_indent$_indent$_indent${_indent}return filtered');
+      buffer.writeln('$_indent$_indent$_indent}');
+      buffer.writeln('$_indent$_indent}');
+    }
     buffer.writeln('$_indent${_indent}let results = try await FlutterBridge.shared.queryEntities(');
     buffer.writeln('$_indent$_indent${_indent}entityIdentifier: "${info.identifier}",');
     buffer.writeln('$_indent$_indent${_indent}identifiers: identifiers');
@@ -595,6 +618,12 @@ class SwiftGenerator {
 
     // suggestedEntities() method
     buffer.writeln('${_indent}func suggestedEntities() async throws -> [${info.className}] {');
+    if (cacheKey != null) {
+      buffer.writeln(
+          '$_indent${_indent}if let cached = Self._readCachedEntities(), !cached.isEmpty {');
+      buffer.writeln('$_indent$_indent${_indent}return cached');
+      buffer.writeln('$_indent$_indent}');
+    }
     buffer.writeln('$_indent${_indent}let results = try await FlutterBridge.shared.suggestedEntities(');
     buffer.writeln('$_indent$_indent${_indent}entityIdentifier: "${info.identifier}"');
     buffer.writeln('$_indent$_indent)');
@@ -603,7 +632,54 @@ class SwiftGenerator {
     buffer.writeln('$_indent$_indent}');
     buffer.writeln('$_indent}');
 
+    if (cacheKey != null) {
+      buffer.writeln();
+      _writeCachedEntityReader(
+          buffer, info, idProp, titleProp, subtitleProp, imageProp);
+    }
+
     buffer.writeln('}');
+  }
+
+  /// Writes the static `_readCachedEntities()` helper used as the cold-start
+  /// fallback. Returns nil when the key is missing, decode fails, or the
+  /// cached payload is empty so callers can fall through to FlutterBridge.
+  void _writeCachedEntityReader(
+    StringBuffer buffer,
+    EntityInfo info,
+    EntityPropertyInfo? idProp,
+    EntityPropertyInfo? titleProp,
+    EntityPropertyInfo? subtitleProp,
+    EntityPropertyInfo? imageProp,
+  ) {
+    buffer.writeln(
+        '$_indent/// Reads cached entities from App Group UserDefaults.');
+    buffer.writeln(
+        '$_indent/// Accepts either a JSON string payload or a pre-decoded array of maps.');
+    buffer.writeln(
+        '${_indent}private static func _readCachedEntities() -> [${info.className}]? {');
+    buffer.writeln(
+        '$_indent${_indent}guard let raw = AppIntentsPlugin.getCached(forKey: cacheKey) else {');
+    buffer.writeln('$_indent$_indent${_indent}return nil');
+    buffer.writeln('$_indent$_indent}');
+    buffer.writeln('$_indent${_indent}let dicts: [[String: Any]]');
+    buffer.writeln('$_indent${_indent}if let array = raw as? [[String: Any]] {');
+    buffer.writeln('$_indent$_indent${_indent}dicts = array');
+    buffer.writeln('$_indent$_indent} else if let jsonString = raw as? String,');
+    buffer.writeln(
+        '$_indent$_indent$_indent${_indent}let data = jsonString.data(using: .utf8),');
+    buffer.writeln(
+        '$_indent$_indent$_indent${_indent}let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {');
+    buffer.writeln('$_indent$_indent${_indent}dicts = parsed');
+    buffer.writeln('$_indent$_indent} else {');
+    buffer.writeln('$_indent$_indent${_indent}return nil');
+    buffer.writeln('$_indent$_indent}');
+    buffer.writeln('$_indent${_indent}let entities: [${info.className}] = dicts.compactMap { dict in');
+    _writeEntityDictMapping(
+        buffer, info, idProp, titleProp, subtitleProp, imageProp);
+    buffer.writeln('$_indent$_indent}');
+    buffer.writeln('$_indent${_indent}return entities');
+    buffer.writeln('$_indent}');
   }
 
   /// Writes the dictionary-to-entity mapping inside compactMap.
@@ -721,7 +797,8 @@ class SwiftGenerator {
     if (intents.any((i) => _hasFileParams(i))) {
       buffer.writeln('import UniformTypeIdentifiers');
     }
-    if (intents.any((i) => _needsCacheImport(i))) {
+    if (intents.any((i) => _needsCacheImport(i)) ||
+        entities.any((e) => e.effectiveCacheKey != null)) {
       buffer.writeln('import app_intents');
     }
     if (entities.any((e) => e.indexed)) {

--- a/packages/app_intents_codegen/lib/src/models/entity_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/entity_info.dart
@@ -30,6 +30,14 @@ class EntityInfo {
   /// Whether to generate EnumerableEntityQuery conformance.
   final bool enumerable;
 
+  /// Optional App Group UserDefaults key for the persisted entity list.
+  ///
+  /// When non-null, the generated EntityQuery reads cached entities from this
+  /// key before waiting on the Flutter executor (cold-start fallback). When
+  /// null but [enumerable] or [indexed] is true, a default key
+  /// `app_intents.entities.<identifier>` is used.
+  final String? persistedCacheKey;
+
   const EntityInfo({
     required this.className,
     required this.identifier,
@@ -41,7 +49,21 @@ class EntityInfo {
     this.displayImageName,
     this.indexed = false,
     this.enumerable = false,
+    this.persistedCacheKey,
   });
+
+  /// Returns the effective cache key to use for App Group fallback, or null
+  /// when no fallback should be generated.
+  ///
+  /// - Returns [persistedCacheKey] verbatim when explicitly set.
+  /// - Returns `app_intents.entities.<identifier>` when [enumerable] or
+  ///   [indexed] is true (auto-fallback for long-lived entities).
+  /// - Returns null otherwise.
+  String? get effectiveCacheKey {
+    if (persistedCacheKey != null) return persistedCacheKey;
+    if (enumerable || indexed) return 'app_intents.entities.$identifier';
+    return null;
+  }
 
   @override
   bool operator ==(Object other) {
@@ -56,6 +78,7 @@ class EntityInfo {
         displayImageName == other.displayImageName &&
         indexed == other.indexed &&
         enumerable == other.enumerable &&
+        persistedCacheKey == other.persistedCacheKey &&
         _listEquals(properties, other.properties);
   }
 
@@ -70,6 +93,7 @@ class EntityInfo {
         displayImageName,
         indexed,
         enumerable,
+        persistedCacheKey,
         Object.hashAll(properties),
       );
 
@@ -78,7 +102,7 @@ class EntityInfo {
       'EntityInfo(className: $className, identifier: $identifier, title: $title, '
       'pluralTitle: $pluralTitle, description: $description, modelType: $modelType, '
       'displayImageName: $displayImageName, indexed: $indexed, enumerable: $enumerable, '
-      'properties: $properties)';
+      'persistedCacheKey: $persistedCacheKey, properties: $properties)';
 }
 
 /// Represents analyzed information about an entity property.

--- a/packages/app_intents_codegen/test/analyzer/entity_analyzer_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/entity_analyzer_test.dart
@@ -258,6 +258,104 @@ void main() {
         expect(result!.indexed, isFalse);
         expect(result!.enumerable, isFalse);
         expect(result!.displayImageName, isNull);
+        expect(result!.persistedCacheKey, isNull);
+      });
+
+      test('extracts persistedCacheKey when provided', () async {
+        final library = await resolveSource('''
+          import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+          @EntitySpec(
+            identifier: 'com.example.team',
+            title: 'Team',
+            pluralTitle: 'Teams',
+            persistedCacheKey: 'com.example.cache.teams',
+          )
+          class TeamEntity extends EntitySpecBase<Team> {}
+
+          class Team {}
+        ''');
+
+        final classElement = findClass(library, 'TeamEntity');
+        final result = analyzer.analyze(classElement);
+
+        expect(result, isNotNull);
+        expect(result!.persistedCacheKey, equals('com.example.cache.teams'));
+        expect(result.effectiveCacheKey, equals('com.example.cache.teams'));
+      });
+
+      test(
+          'effectiveCacheKey falls back to default identifier-based key when indexed',
+          () async {
+        final library = await resolveSource('''
+          import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+          @EntitySpec(
+            identifier: 'com.example.team',
+            title: 'Team',
+            pluralTitle: 'Teams',
+            indexed: true,
+          )
+          class TeamEntity extends EntitySpecBase<Team> {}
+
+          class Team {}
+        ''');
+
+        final classElement = findClass(library, 'TeamEntity');
+        final result = analyzer.analyze(classElement);
+
+        expect(result, isNotNull);
+        expect(result!.persistedCacheKey, isNull);
+        expect(result.effectiveCacheKey,
+            equals('app_intents.entities.com.example.team'));
+      });
+
+      test(
+          'effectiveCacheKey falls back to default identifier-based key when enumerable',
+          () async {
+        final library = await resolveSource('''
+          import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+          @EntitySpec(
+            identifier: 'com.example.team',
+            title: 'Team',
+            pluralTitle: 'Teams',
+            enumerable: true,
+          )
+          class TeamEntity extends EntitySpecBase<Team> {}
+
+          class Team {}
+        ''');
+
+        final classElement = findClass(library, 'TeamEntity');
+        final result = analyzer.analyze(classElement);
+
+        expect(result, isNotNull);
+        expect(result!.persistedCacheKey, isNull);
+        expect(result.effectiveCacheKey,
+            equals('app_intents.entities.com.example.team'));
+      });
+
+      test('effectiveCacheKey is null when no cache hint is provided',
+          () async {
+        final library = await resolveSource('''
+          import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+          @EntitySpec(
+            identifier: 'com.example.team',
+            title: 'Team',
+            pluralTitle: 'Teams',
+          )
+          class TeamEntity extends EntitySpecBase<Team> {}
+
+          class Team {}
+        ''');
+
+        final classElement = findClass(library, 'TeamEntity');
+        final result = analyzer.analyze(classElement);
+
+        expect(result, isNotNull);
+        expect(result!.effectiveCacheKey, isNull);
       });
     });
 

--- a/packages/app_intents_codegen/test/generator/swift_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_test.dart
@@ -1594,6 +1594,152 @@ void main() {
         expect(result, isNot(contains('IndexedEntity')));
         expect(result, isNot(contains('CoreSpotlight')));
       });
+
+      test(
+          'generates App Group cache fallback in EntityQuery when persistedCacheKey is set',
+          () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          persistedCacheKey: 'com.example.cache.teams',
+          properties: [
+            EntityPropertyInfo(
+                fieldName: 'id',
+                dartType: 'String',
+                role: EntityPropertyRole.id),
+            EntityPropertyInfo(
+                fieldName: 'name',
+                dartType: 'String',
+                role: EntityPropertyRole.title),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(result, contains('import app_intents'));
+        expect(result,
+            contains('static let cacheKey = "com.example.cache.teams"'));
+        expect(result, contains('Self._readCachedEntities()'));
+        expect(result,
+            contains(r'cached.filter { identifiers.contains($0.id) }'));
+        expect(result,
+            contains('AppIntentsPlugin.getCached(forKey: cacheKey)'));
+        expect(result, contains('private static func _readCachedEntities()'));
+      });
+
+      test(
+          'uses default cache key when persistedCacheKey is null but indexed is true',
+          () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          indexed: true,
+          properties: [
+            EntityPropertyInfo(
+                fieldName: 'id',
+                dartType: 'String',
+                role: EntityPropertyRole.id),
+            EntityPropertyInfo(
+                fieldName: 'name',
+                dartType: 'String',
+                role: EntityPropertyRole.title),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(
+            result,
+            contains(
+                'static let cacheKey = "app_intents.entities.com.example.team"'));
+        expect(result, contains('Self._readCachedEntities()'));
+      });
+
+      test(
+          'uses default cache key when persistedCacheKey is null but enumerable is true',
+          () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          enumerable: true,
+          properties: [
+            EntityPropertyInfo(
+                fieldName: 'id',
+                dartType: 'String',
+                role: EntityPropertyRole.id),
+            EntityPropertyInfo(
+                fieldName: 'name',
+                dartType: 'String',
+                role: EntityPropertyRole.title),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(
+            result,
+            contains(
+                'static let cacheKey = "app_intents.entities.com.example.team"'));
+        expect(result, contains('Self._readCachedEntities()'));
+      });
+
+      test(
+          'does not generate cache fallback when persistedCacheKey is null and not enumerable/indexed',
+          () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          properties: [
+            EntityPropertyInfo(
+                fieldName: 'id',
+                dartType: 'String',
+                role: EntityPropertyRole.id),
+            EntityPropertyInfo(
+                fieldName: 'name',
+                dartType: 'String',
+                role: EntityPropertyRole.title),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(result, isNot(contains('cacheKey')));
+        expect(result, isNot(contains('_readCachedEntities')));
+        expect(result, isNot(contains('import app_intents')));
+      });
+
+      test('uses the entity\'s id field name for the cache filter', () {
+        final entityInfo = EntityInfo(
+          className: 'TaskEntity',
+          identifier: 'com.example.task',
+          title: 'Task',
+          pluralTitle: 'Tasks',
+          persistedCacheKey: 'com.example.cache.tasks',
+          properties: [
+            EntityPropertyInfo(
+                fieldName: 'taskId',
+                dartType: 'String',
+                role: EntityPropertyRole.id),
+            EntityPropertyInfo(
+                fieldName: 'title',
+                dartType: 'String',
+                role: EntityPropertyRole.title),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(result,
+            contains(r'cached.filter { identifiers.contains($0.taskId) }'));
+      });
     });
 
     group('generateAppShortcutsProvider', () {

--- a/packages/app_intents_codegen/test/test_utils.dart
+++ b/packages/app_intents_codegen/test/test_utils.dart
@@ -87,6 +87,7 @@ Future<LibraryElement> resolveSource(String source) async {
           final String? displayImageName;
           final bool indexed;
           final bool enumerable;
+          final String? persistedCacheKey;
 
           const EntitySpec({
             required this.identifier,
@@ -96,6 +97,7 @@ Future<LibraryElement> resolveSource(String source) async {
             this.displayImageName,
             this.indexed = false,
             this.enumerable = false,
+            this.persistedCacheKey,
           });
         }
       ''',


### PR DESCRIPTION
## Summary
- Generated Swift `EntityQuery` now reads cached entities from App Group `UserDefaults` synchronously before waiting on `FlutterBridge`, mitigating the cold-start `entityQueryNotConfigured` error.
- Adds `@EntitySpec(persistedCacheKey: ...)` as an opt-in. When unset but `enumerable: true` or `indexed: true`, codegen uses `app_intents.entities.<identifier>` as the default key.
- Accepts both JSON-encoded strings and pre-decoded `[[String: Any]]` payloads.
- Wires the example app's `TaskRepository` to mirror tasks under the entity cache key so the feature is exercised end-to-end.
- Documents the payload-shape contract (entity field names, accepted types) and key-namespacing behavior in `entity_spec.dart` and `CLAUDE.md`.

Closes #26

## Why
When iOS suspends or kills the host app and Siri/Shortcuts fires an `EntityQuery`, the Flutter engine may not finish initializing within `FlutterBridge`'s 5-second timeout, surfacing as a generic ""internal error"" on the user side. The data is usually already in App Group `UserDefaults` (via the existing `setCachedValue` / `configureStorage` APIs), so the EntityQuery can short-circuit the engine boot when cached data is fresh.

## Manual verification required
The cold-start fallback path can only be fully validated on a physical device with a killed app. The unit tests cover codegen mechanics, but downstream hosts must verify:

- [ ] On a cold start (force-quit the host app, wait, then fire an AppShortcut), the entity picker resolves without an ""internal error""
- [ ] `AppIntentsPlugin.configure(appGroupIdentifier:)` is invoked early enough — note that `WFIsolatedShortcutRunner` is a separate process where `AppDelegate` does not run. If your extension process can't reach the AppDelegate path, a follow-up will add a generated `configure()` call in the Swift output (out of scope for this PR).
- [ ] The Dart `setCachedValue` key matches the Swift-side `cacheKey` exactly (including `persistedCacheKey` verbatim, or the `app_intents.entities.<identifier>` default for `enumerable`/`indexed`)

## Test plan
- [x] `dart test` in `app_intents_codegen` — all 239 tests pass (7 new tests: 4 analyzer-side, 4 generator-side covering explicit key, enumerable default, indexed default, custom id field name, no-fallback case)
- [x] `dart test` in `app_intents_annotations` — 7 tests pass
- [x] `flutter test` in `app` — example app widget tests pass
- [x] `dart analyze` clean across all packages
- [x] Swift codegen regenerated for the example app — confirms `import app_intents`, `cacheKey`, `entities(for:)` / `suggestedEntities()` fallback paths, and `_readCachedEntities()` JSON/pre-decoded handling
- [ ] On-device cold-start verification (requires reviewer's setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)