### PR TITLE
feat(codegen): opt-in WWDC26 experimental generation + Intent execution control (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,18 @@ docs/
 | Android Minimum | **API 36** (Android 16, for AppFunctions) |
 | Android AppFunctions | **Jetpack `androidx.appfunctions` 1.0.0-alpha09** |
 | Cross-Process Storage (iOS) | **App Group UserDefaults** (explicit configuration required) |
+| WWDC26 New APIs | **Opt-in, default OFF** (`#if APP_INTENTS_WWDC26`, dual-branch generation) |
 
 ## Implementation Status
 
 ### Completed
+- **WWDC26 experimental codegen (opt-in, #52 Intent execution control)**
+  - `ExperimentalFeatures` config (`lib/src/experimental/experimental_features.dart`): master switch + per-feature set; default OFF reproduces stable output byte-for-byte
+  - CLI `generate_swift`: `--experimental-wwdc26` (master) + `--experimental=long-running,app-schema` (per-feature)
+  - `@IntentSpec(longRunning:, cancellable:, executionTargets:)` + `IntentExecutionTarget` enum
+  - `SwiftGenerator` emits **two struct variants per intent**: WWDC26 form in `#if APP_INTENTS_WWDC26`, stable form in `#else` (so released-SDK builds without the flag still compile)
+  - Verified: 271 codegen + 8 annotation tests green; **dual-branch `swiftc -typecheck` green against Xcode 27 beta iOS 27 SDK** (with and without `-D APP_INTENTS_WWDC26`)
+  - See "WWDC26 Experimental Code Generation" under Code Conventions for the SDK-verified API facts
 - `app_intents_annotations`: All annotations defined
   - `@IntentSpec` (with `urlScheme`/`urlAction`, `resultDialogTemplate`, `parameterSummary`)
   - `@IntentParam` (with `entityType` for entity picker, `enumType` for AppEnum parameters)
@@ -235,6 +243,50 @@ The SwiftGenerator auto-selects the execution mode based on `@IntentSpec` config
 | set | any | URL scheme | Opens URL via `UIApplication.shared.open()` |
 | null | `foreground` | Cache | Caches params to UserDefaults, app opens, Flutter reads pending |
 | null | null/`background` | FlutterBridge | Direct MethodChannel via `FlutterBridge.shared.invoke()` |
+
+### WWDC26 Experimental Code Generation
+New WWDC26 App Intents APIs are emitted **opt-in (default OFF)**. They cannot use
+`@available` gating because the symbols **do not exist in the stable SDK at all** —
+`@available` only guards the runtime OS version, not symbol existence. So "OFF = do
+not emit those lines" is mandatory.
+
+**Flag mechanism** (`ExperimentalFeatures`):
+- `--experimental-wwdc26` master switch (OFF → nothing experimental is emitted).
+- `--experimental=<flag>` per-feature (`long-running`, `app-schema`). Master ON with
+  no per-feature flag = all features; with flags = only those.
+- Thread the flag through the **CLI + SwiftGenerator only** until a feature changes
+  Dart output (then also wire `build.yaml`/`builder.dart`). #52 is Swift-only.
+
+**Dual-branch emission**: when an intent uses an experimental execution attribute,
+`SwiftGenerator` emits two whole structs:
+```
+#if APP_INTENTS_WWDC26
+@available(iOS 27.0, *)
+struct Foo: AppIntent, LongRunningIntent, CancellableIntent { ... }   // WWDC26 form
+#else
+@available(iOS 17.0, *)
+struct Foo: AppIntent { ... }                                          // stable fallback
+#endif
+```
+The `#else` is **mandatory**: a user who enables experimental codegen but hasn't set
+the `APP_INTENTS_WWDC26` build flag must still get compiling (stable) Swift.
+
+**SDK-verified API facts** (from Xcode 27 beta `.swiftinterface`, not the issue drafts):
+- Apple jumped to **year-based versioning**: WWDC26 APIs are **iOS 27**, not iOS 26.
+- `LongRunningIntent : ProgressReportingIntent` — **iOS 27.0**; empty protocol;
+  `performBackgroundTask(options:operation:)` and `performBackgroundTask(options:operation:onCancel:)`
+  (the latter requires `Self: CancellableIntent`) come from an extension. `@discardableResult`.
+- `CancellableIntent` — **iOS 26.4**; `withIntentCancellationHandler(operation:onCancel:isolation:)` + `IntentCancellationReason`.
+- `IntentExecutionTargets` — **iOS 27.0**; OptionSet with `.main` / `.appIntentsExtension`
+  / `.widgetKitExtension` (not `.widget`); used via `static var allowedExecutionTargets`.
+- `ProgressReportingIntent.progress` is **extension-provided** (no member to implement).
+
+**How to verify (the load-bearing check)**: golden/unit tests only assert "the strings
+I emitted came out"; they pass while emitting Swift that won't compile. Always
+`swiftc -typecheck` the generated form **twice** (with and without `-D APP_INTENTS_WWDC26`)
+against the beta SDK. Get exact signatures from the SDK directly:
+- Doc search via `xcrun mcpbridge` → `DocumentationSearch` (semantic).
+- Ground truth: `…/AppIntents.framework/Modules/AppIntents.swiftmodule/arm64e-apple-ios.swiftinterface`.
 
 ### TDD Approach
 Follow Red-Green-Refactor:

--- a/packages/app_intents_annotations/lib/app_intents_annotations.dart
+++ b/packages/app_intents_annotations/lib/app_intents_annotations.dart
@@ -5,6 +5,7 @@ export 'src/annotations/app_shortcut.dart';
 export 'src/annotations/entity_params.dart';
 export 'src/annotations/entity_spec.dart';
 export 'src/annotations/enum_spec.dart';
+export 'src/annotations/intent_execution_target.dart';
 export 'src/annotations/intent_mode.dart';
 export 'src/annotations/intent_param.dart';
 export 'src/annotations/intent_spec.dart';

--- a/packages/app_intents_annotations/lib/src/annotations/intent_execution_target.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/intent_execution_target.dart
@@ -1,0 +1,22 @@
+/// A target process an intent is allowed to execute in.
+///
+/// Maps to the WWDC26 `IntentExecutionTargets` option set (iOS 27+). When you
+/// reuse intents between your app, a widget extension, or an App Intents
+/// extension via a Swift package, the system may run the intent from any of
+/// them. Use these values with `@IntentSpec(executionTargets: ...)` to restrict
+/// execution to specific targets.
+///
+/// This is an **experimental WWDC26 feature**: the generated
+/// `allowedExecutionTargets` is only emitted when experimental code generation
+/// is enabled, and is wrapped in a `#if APP_INTENTS_WWDC26` compilation
+/// condition so it compiles only against a beta SDK.
+enum IntentExecutionTarget {
+  /// The main app process. Generates `.main`.
+  main,
+
+  /// An App Intents extension process. Generates `.appIntentsExtension`.
+  appIntentsExtension,
+
+  /// A WidgetKit extension process. Generates `.widgetKitExtension`.
+  widgetKitExtension,
+}

--- a/packages/app_intents_annotations/lib/src/annotations/intent_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/intent_spec.dart
@@ -1,3 +1,4 @@
+import 'intent_execution_target.dart';
 import 'intent_mode.dart';
 
 /// Annotation to specify an app intent.
@@ -51,6 +52,33 @@ class IntentSpec {
   /// When [urlScheme] is set, foreground mode is implied automatically.
   final IntentMode? supportedModes;
 
+  /// **Experimental (WWDC26, iOS 27+).** Marks the intent as long-running so it
+  /// can exceed the standard 30-second background limit.
+  ///
+  /// When experimental code generation is enabled, the generated Swift conforms
+  /// to `LongRunningIntent` and wraps the work in `performBackgroundTask(...)`.
+  /// Long-running intents must run in the background (no [urlScheme], no
+  /// [IntentMode.foreground]). Has no effect unless experimental generation is
+  /// enabled.
+  final bool longRunning;
+
+  /// **Experimental (WWDC26, iOS 26.4+).** Marks the intent as cancellable so it
+  /// can respond to graceful cancellation.
+  ///
+  /// When experimental code generation is enabled, the generated Swift conforms
+  /// to `CancellableIntent` and wraps the work in a cancellation handler that
+  /// receives an `IntentCancellationReason`. Cancellable intents must run in the
+  /// background. Has no effect unless experimental generation is enabled.
+  final bool cancellable;
+
+  /// **Experimental (WWDC26, iOS 27+).** Restricts which processes may run this
+  /// intent.
+  ///
+  /// When experimental code generation is enabled, the generated Swift emits
+  /// `static var allowedExecutionTargets: IntentExecutionTargets`. Has no effect
+  /// unless experimental generation is enabled.
+  final List<IntentExecutionTarget>? executionTargets;
+
   const IntentSpec({
     required this.identifier,
     required this.title,
@@ -61,6 +89,9 @@ class IntentSpec {
     this.resultDialogTemplate,
     this.parameterSummary,
     this.supportedModes,
+    this.longRunning = false,
+    this.cancellable = false,
+    this.executionTargets,
   });
 }
 

--- a/packages/app_intents_codegen/bin/generate_swift.dart
+++ b/packages/app_intents_codegen/bin/generate_swift.dart
@@ -54,6 +54,21 @@ void main(List<String> arguments) async {
       defaultsTo: 'en',
     )
     ..addFlag(
+      'experimental-wwdc26',
+      negatable: false,
+      help:
+          'Master switch for opt-in WWDC26 experimental code generation '
+          '(default off). Generated code is wrapped in #if APP_INTENTS_WWDC26.',
+    )
+    ..addMultiOption(
+      'experimental',
+      help:
+          'Narrow experimental generation to specific features '
+          '(comma-separated). Requires --experimental-wwdc26. '
+          'When omitted (with the master switch on), all features are emitted.',
+      allowed: ExperimentalFeature.allFlags,
+    )
+    ..addFlag(
       'help',
       abbr: 'h',
       negatable: false,
@@ -81,6 +96,7 @@ void main(List<String> arguments) async {
   final xcstringsPath = results['xcstrings'] as String?;
   final translationsPath = results['translations'] as String?;
   final sourceLanguage = results['source-language'] as String;
+  final experimental = _resolveExperimental(results);
 
   await generateSwift(
     inputDir: inputDir,
@@ -89,7 +105,29 @@ void main(List<String> arguments) async {
     xcstringsPath: xcstringsPath,
     translationsPath: translationsPath,
     sourceLanguage: sourceLanguage,
+    experimental: experimental,
   );
+}
+
+/// Builds the [ExperimentalFeatures] configuration from CLI results.
+ExperimentalFeatures _resolveExperimental(ArgResults results) {
+  final masterEnabled = results['experimental-wwdc26'] as bool;
+  final flags = results['experimental'] as List<String>;
+
+  if (flags.isNotEmpty && !masterEnabled) {
+    stderr.writeln(
+      'Warning: --experimental was given without --experimental-wwdc26; '
+      'no experimental code will be emitted.',
+    );
+  }
+
+  final enabled = <ExperimentalFeature>{};
+  for (final flag in flags) {
+    final feature = ExperimentalFeature.fromFlag(flag);
+    if (feature != null) enabled.add(feature);
+  }
+
+  return ExperimentalFeatures(masterEnabled: masterEnabled, enabled: enabled);
 }
 
 void _printUsage(ArgParser parser) {
@@ -113,6 +151,7 @@ Future<void> generateSwift({
   String? xcstringsPath,
   String? translationsPath,
   String sourceLanguage = 'en',
+  ExperimentalFeatures experimental = ExperimentalFeatures.none,
 }) async {
   final analyzeResult = await analyzeSourceFiles(inputDir);
 
@@ -124,7 +163,7 @@ Future<void> generateSwift({
   }
 
   // Generate Swift code
-  final generator = SwiftGenerator();
+  final generator = SwiftGenerator(experimental: experimental);
   final swiftCode = generator.generateAll(
     intents: analyzeResult.intents,
     entities: analyzeResult.entities,

--- a/packages/app_intents_codegen/lib/app_intents_codegen.dart
+++ b/packages/app_intents_codegen/lib/app_intents_codegen.dart
@@ -8,6 +8,7 @@ export 'src/analyzer/entity_analyzer.dart';
 export 'src/analyzer/enum_analyzer.dart';
 export 'src/analyzer/intent_analyzer.dart';
 export 'src/analyzer/shortcut_analyzer.dart';
+export 'src/experimental/experimental_features.dart';
 export 'src/generator/dart_generator.dart';
 export 'src/generator/kotlin_generator.dart';
 export 'src/generator/swift_generator.dart';

--- a/packages/app_intents_codegen/lib/src/analyzer/intent_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/intent_analyzer.dart
@@ -50,6 +50,13 @@ class IntentAnalyzer {
     final supportedModes = _parseSupportedModes(
       annotation.getField('supportedModes'),
     );
+    final longRunning =
+        annotation.getField('longRunning')?.toBoolValue() ?? false;
+    final cancellable =
+        annotation.getField('cancellable')?.toBoolValue() ?? false;
+    final executionTargets = _parseExecutionTargets(
+      annotation.getField('executionTargets'),
+    );
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -60,6 +67,18 @@ class IntentAnalyzer {
     if (title == null) {
       throw InvalidGenerationSourceError(
         '@IntentSpec requires a "title" field.',
+        element: element,
+      );
+    }
+
+    // Long-running / cancellable intents are inherently background work; they
+    // cannot also open the app via URL scheme or foreground mode.
+    if ((longRunning || cancellable) &&
+        (urlScheme != null || supportedModes == IntentModeType.foreground)) {
+      throw InvalidGenerationSourceError(
+        '@IntentSpec "longRunning"/"cancellable" require background execution '
+        'and cannot be combined with "urlScheme" or '
+        'supportedModes: IntentMode.foreground.',
         element: element,
       );
     }
@@ -78,7 +97,37 @@ class IntentAnalyzer {
       resultDialogTemplate: resultDialogTemplate,
       parameterSummary: parameterSummary,
       supportedModes: supportedModes,
+      longRunning: longRunning,
+      cancellable: cancellable,
+      executionTargets: executionTargets,
     );
+  }
+
+  /// Parses the `executionTargets` list of `IntentExecutionTarget` enum values.
+  ///
+  /// Returns `null` when the field is absent/null, preserving the "not
+  /// specified" distinction from an explicitly empty list.
+  List<IntentExecutionTargetType>? _parseExecutionTargets(DartObject? field) {
+    if (field == null || field.isNull) {
+      return null;
+    }
+    final values = field.toListValue();
+    if (values == null) {
+      return null;
+    }
+    final result = <IntentExecutionTargetType>[];
+    for (final element in values) {
+      final index = element.getField('index')?.toIntValue();
+      switch (index) {
+        case 0:
+          result.add(IntentExecutionTargetType.main);
+        case 1:
+          result.add(IntentExecutionTargetType.appIntentsExtension);
+        case 2:
+          result.add(IntentExecutionTargetType.widgetKitExtension);
+      }
+    }
+    return result;
   }
 
   IntentModeType? _parseSupportedModes(DartObject? field) {

--- a/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
+++ b/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
@@ -1,0 +1,99 @@
+/// Opt-in WWDC26 experimental code-generation features.
+///
+/// Each value names a self-contained feature whose generated Swift relies on an
+/// unreleased/beta iOS SDK (iOS 26.4 / iOS 27+). Because the symbols do not
+/// exist in the stable SDK at all, `@available` cannot guard them — the only
+/// safe gate is "do not emit those lines". These features are therefore
+/// disabled by default and, when enabled, the generated code is additionally
+/// wrapped in a `#if APP_INTENTS_WWDC26` compilation condition so the consuming
+/// project can also toggle it from build settings.
+///
+/// Selected via the CLI `--experimental=<flag>` (comma-separated) and gated by
+/// the `--experimental-wwdc26` master switch.
+enum ExperimentalFeature {
+  /// Intent execution control (#52): `LongRunningIntent`, `CancellableIntent`,
+  /// and `allowedExecutionTargets` / `IntentExecutionTargets`.
+  longRunning('long-running'),
+
+  /// App Schema domain conformance (#49): `@AppEntity(schema:)` and friends.
+  appSchema('app-schema');
+
+  const ExperimentalFeature(this.flag);
+
+  /// The token used on the CLI: `--experimental=<flag>`.
+  final String flag;
+
+  /// All CLI flag tokens, in declaration order.
+  static List<String> get allFlags =>
+      ExperimentalFeature.values.map((f) => f.flag).toList();
+
+  /// Resolves a CLI flag token to its [ExperimentalFeature], or `null` if the
+  /// token is not recognized.
+  static ExperimentalFeature? fromFlag(String value) {
+    for (final feature in ExperimentalFeature.values) {
+      if (feature.flag == value) return feature;
+    }
+    return null;
+  }
+}
+
+/// Resolved opt-in configuration for WWDC26 experimental code generation.
+///
+/// Defaults to everything OFF ([none]), which reproduces the stable output
+/// byte-for-byte. The master switch combines with the per-feature set:
+///
+/// - master OFF → nothing experimental is emitted, regardless of [enabled].
+/// - master ON with an empty [enabled] set → every feature is emitted
+///   (the "just turn it all on" shorthand).
+/// - master ON with a non-empty [enabled] set → only the listed features.
+class ExperimentalFeatures {
+  /// Creates a configuration. Prefer [none] for the default.
+  const ExperimentalFeatures({
+    this.masterEnabled = false,
+    this.enabled = const {},
+  });
+
+  /// The default: all experimental generation disabled (stable output).
+  static const ExperimentalFeatures none = ExperimentalFeatures();
+
+  /// The master switch (`--experimental-wwdc26`).
+  final bool masterEnabled;
+
+  /// The explicitly selected per-feature flags. An empty set with
+  /// [masterEnabled] true means "all features".
+  final Set<ExperimentalFeature> enabled;
+
+  /// Whether [feature] should be emitted under the current configuration.
+  bool isEnabled(ExperimentalFeature feature) {
+    if (!masterEnabled) return false;
+    if (enabled.isEmpty) return true;
+    return enabled.contains(feature);
+  }
+
+  /// Whether any experimental output is active at all.
+  bool get anyEnabled => masterEnabled;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ExperimentalFeatures &&
+      other.masterEnabled == masterEnabled &&
+      _setEquals(other.enabled, enabled);
+
+  @override
+  int get hashCode => Object.hash(
+    masterEnabled,
+    Object.hashAllUnordered(enabled),
+  );
+
+  @override
+  String toString() =>
+      'ExperimentalFeatures(masterEnabled: $masterEnabled, enabled: $enabled)';
+}
+
+bool _setEquals<T>(Set<T> a, Set<T> b) {
+  if (a.length != b.length) return false;
+  for (final element in a) {
+    if (!b.contains(element)) return false;
+  }
+  return true;
+}

--- a/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
+++ b/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
@@ -80,10 +80,8 @@ class ExperimentalFeatures {
       _setEquals(other.enabled, enabled);
 
   @override
-  int get hashCode => Object.hash(
-    masterEnabled,
-    Object.hashAllUnordered(enabled),
-  );
+  int get hashCode =>
+      Object.hash(masterEnabled, Object.hashAllUnordered(enabled));
 
   @override
   String toString() =>

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -1,3 +1,4 @@
+import '../experimental/experimental_features.dart';
 import '../models/entity_info.dart';
 import '../models/enum_info.dart';
 import '../models/intent_info.dart';
@@ -29,6 +30,15 @@ class AppShortcutInfo {
 /// This generator produces Swift code that can be used in iOS 17+ applications
 /// to integrate with the App Intents framework.
 class SwiftGenerator {
+  /// Creates a Swift generator.
+  ///
+  /// [experimental] controls opt-in WWDC26 code generation. It defaults to
+  /// [ExperimentalFeatures.none], reproducing the stable output exactly.
+  const SwiftGenerator({this.experimental = ExperimentalFeatures.none});
+
+  /// Opt-in WWDC26 experimental code-generation configuration.
+  final ExperimentalFeatures experimental;
+
   /// Mapping of Dart types to Swift types.
   static const _typeMapping = <String, String>{
     'String': 'String',
@@ -324,33 +334,83 @@ class SwiftGenerator {
 
     final indent2 = '$_indent$_indent';
 
-    // Build params dictionary
+    _writeFlutterBridgeInvoke(buffer, info, indent2);
+
+    // Clean up temp files after FlutterBridge invoke completes
+    _writeFileParamCleanup(buffer, info, indent2);
+
+    _writeReturnResult(buffer, info, indent2);
+    buffer.writeln('$_indent}');
+  }
+
+  /// Writes a `FlutterBridge.shared.invoke(...)` call at [baseIndent].
+  ///
+  /// Shared by the stable FlutterBridge perform() and the experimental
+  /// long-running/cancellable perform(), where it sits inside a wrapping
+  /// closure at a deeper indent.
+  void _writeFlutterBridgeInvoke(
+    StringBuffer buffer,
+    IntentInfo info,
+    String baseIndent,
+  ) {
+    buffer.writeln('${baseIndent}let _ = try await FlutterBridge.shared.invoke(');
+    buffer.writeln('$baseIndent${_indent}intent: "${info.className}",');
     if (info.parameters.isEmpty) {
-      buffer.writeln(
-        '${indent2}let _ = try await FlutterBridge.shared.invoke(',
-      );
-      buffer.writeln('$indent2${_indent}intent: "${info.className}",');
-      buffer.writeln('$indent2${_indent}params: [:]');
-      buffer.writeln('$indent2)');
+      buffer.writeln('$baseIndent${_indent}params: [:]');
     } else {
-      buffer.writeln(
-        '${indent2}let _ = try await FlutterBridge.shared.invoke(',
-      );
-      buffer.writeln('$indent2${_indent}intent: "${info.className}",');
-      buffer.writeln('$indent2${_indent}params: [');
+      buffer.writeln('$baseIndent${_indent}params: [');
       for (var i = 0; i < info.parameters.length; i++) {
         final param = info.parameters[i];
         final comma = i < info.parameters.length - 1 ? ',' : '';
         final valueExpr = _paramValueExpression(param);
         buffer.writeln(
-          '$_indent$_indent$_indent$_indent"${param.fieldName}": $valueExpr$comma',
+          '$baseIndent$_indent$_indent"${param.fieldName}": $valueExpr$comma',
         );
       }
-      buffer.writeln('$indent2$_indent]');
-      buffer.writeln('$indent2)');
+      buffer.writeln('$baseIndent$_indent]');
+    }
+    buffer.writeln('$baseIndent)');
+  }
+
+  /// Writes the experimental perform() that wraps the background invoke in
+  /// `performBackgroundTask` and/or `withIntentCancellationHandler`.
+  ///
+  /// An intent that only restricts `executionTargets` (without long-running or
+  /// cancellable) keeps the standard background perform().
+  void _writeExperimentalPerformMethod(StringBuffer buffer, IntentInfo info) {
+    if (!info.longRunning && !info.cancellable) {
+      _writeFlutterBridgePerformMethod(buffer, info);
+      return;
     }
 
-    // Clean up temp files after FlutterBridge invoke completes
+    _writePerformSignature(buffer, info);
+    _writeFileParamSerializations(buffer, info);
+
+    final indent2 = '$_indent$_indent';
+    final indent3 = '$_indent$_indent$_indent';
+
+    // Long-running work uses performBackgroundTask; cancellable-only work uses
+    // the cancellation handler. Both take the operation as a trailing closure.
+    // When the intent is both long-running and cancellable, the combined
+    // performBackgroundTask(operation:onCancel:) overload (which requires
+    // CancellableIntent conformance) is used.
+    final wrapper = info.longRunning
+        ? 'performBackgroundTask'
+        : 'withIntentCancellationHandler';
+    buffer.writeln('${indent2}try await $wrapper {');
+    _writeFlutterBridgeInvoke(buffer, info, indent3);
+    if (info.cancellable) {
+      buffer.writeln('$indent2} onCancel: { reason in');
+      buffer.writeln(
+        '$indent3// The system cancelled this intent; `reason` explains why.',
+      );
+      buffer.writeln('$indent3// Perform best-effort cleanup here.');
+      buffer.writeln('$indent2}');
+    } else {
+      buffer.writeln('$indent2}');
+    }
+
+    // Clean up temp files after the background work completes.
     _writeFileParamCleanup(buffer, info, indent2);
 
     _writeReturnResult(buffer, info, indent2);
@@ -975,29 +1035,44 @@ class SwiftGenerator {
   }
 
   /// Generates intent body without import statement.
+  ///
+  /// When experimental execution control is enabled for this intent, emits two
+  /// variants guarded by a compilation condition: the WWDC26 form inside
+  /// `#if APP_INTENTS_WWDC26` and the stable form inside `#else`, so projects
+  /// that build against a released SDK (without the `APP_INTENTS_WWDC26` flag)
+  /// still compile.
   void _generateIntentBody(StringBuffer buffer, IntentInfo info) {
-    // Availability and struct declaration
+    if (_usesExperimentalExecution(info)) {
+      buffer.writeln('#if APP_INTENTS_WWDC26');
+      _generateExperimentalIntentBody(buffer, info);
+      buffer.writeln();
+      buffer.writeln('#else');
+      _generateStableIntentBody(buffer, info);
+      buffer.writeln();
+      buffer.write('#endif');
+    } else {
+      _generateStableIntentBody(buffer, info);
+    }
+  }
+
+  /// Whether [info] should emit the experimental WWDC26 execution-control form.
+  ///
+  /// Requires both the opt-in `long-running` feature to be enabled and the
+  /// intent to actually declare one of the experimental execution attributes.
+  bool _usesExperimentalExecution(IntentInfo info) {
+    if (!experimental.isEnabled(ExperimentalFeature.longRunning)) return false;
+    return info.longRunning ||
+        info.cancellable ||
+        (info.executionTargets != null && info.executionTargets!.isNotEmpty);
+  }
+
+  /// Generates the stable (released-SDK) intent struct.
+  void _generateStableIntentBody(StringBuffer buffer, IntentInfo info) {
     buffer.writeln('@available(iOS 17.0, *)');
     buffer.writeln('struct ${info.className}: AppIntent {');
 
-    // Title
-    buffer.writeln(
-      '$_indent'
-      'static var title: LocalizedStringResource = "${info.title}"',
-    );
-
-    // Description (if present)
-    if (info.description != null) {
-      buffer.writeln(
-        '$_indent'
-        'static var description: IntentDescription =',
-      );
-      final escapedDesc = info.description!.replaceAll('\n', '\\n');
-      buffer.writeln(
-        '$_indent$_indent'
-        'IntentDescription("$escapedDesc")',
-      );
-    }
+    _writeIntentTitle(buffer, info);
+    _writeIntentDescription(buffer, info);
 
     // supportedModes / openAppWhenRun
     if (_needsForeground(info)) {
@@ -1010,30 +1085,114 @@ class SwiftGenerator {
       buffer.writeln('${_indent}static var openAppWhenRun: Bool { true }');
     }
 
-    // Parameter summary
-    if (info.parameterSummary != null) {
-      buffer.writeln();
-      final summaryStr = _interpolateParameterSummary(info.parameterSummary!);
-      buffer.writeln(
-        '${_indent}static var parameterSummary: some ParameterSummary {',
-      );
-      buffer.writeln('$_indent${_indent}Summary("$summaryStr")');
-      buffer.writeln('$_indent}');
-    }
+    _writeParameterSummary(buffer, info);
+    _writeIntentParameters(buffer, info);
 
-    // Parameters
-    if (info.parameters.isNotEmpty) {
-      buffer.writeln();
-      for (final param in info.parameters) {
-        _writeParameter(buffer, param);
-      }
-    }
-
-    // Perform method
     buffer.writeln();
     _writePerformMethod(buffer, info);
 
     buffer.write('}');
+  }
+
+  /// Generates the experimental WWDC26 intent struct.
+  ///
+  /// Conforms to `LongRunningIntent` and/or `CancellableIntent` as declared,
+  /// emits `allowedExecutionTargets`, and wraps the background work in
+  /// `performBackgroundTask` / `withIntentCancellationHandler`. The whole struct
+  /// is gated at the minimum OS version the chosen APIs require (so we avoid the
+  /// problem of conditionally conforming to a newer-OS protocol).
+  void _generateExperimentalIntentBody(StringBuffer buffer, IntentInfo info) {
+    final hasExecutionTargets =
+        info.executionTargets != null && info.executionTargets!.isNotEmpty;
+
+    final conformances = <String>['AppIntent'];
+    if (info.longRunning) conformances.add('LongRunningIntent');
+    if (info.cancellable) conformances.add('CancellableIntent');
+
+    // LongRunningIntent and IntentExecutionTargets are iOS 27+; CancellableIntent
+    // on its own is iOS 26.4+.
+    final minVersion = (info.longRunning || hasExecutionTargets)
+        ? '27.0'
+        : '26.4';
+
+    buffer.writeln('@available(iOS $minVersion, *)');
+    buffer.writeln('struct ${info.className}: ${conformances.join(', ')} {');
+
+    _writeIntentTitle(buffer, info);
+    _writeIntentDescription(buffer, info);
+
+    if (hasExecutionTargets) {
+      final members = info.executionTargets!
+          .map(_executionTargetToSwift)
+          .join(', ');
+      buffer.writeln();
+      buffer.writeln(
+        '${_indent}static var allowedExecutionTargets: IntentExecutionTargets { [$members] }',
+      );
+    }
+
+    _writeParameterSummary(buffer, info);
+    _writeIntentParameters(buffer, info);
+
+    buffer.writeln();
+    _writeExperimentalPerformMethod(buffer, info);
+
+    buffer.write('}');
+  }
+
+  /// Writes the static `title` declaration.
+  void _writeIntentTitle(StringBuffer buffer, IntentInfo info) {
+    buffer.writeln(
+      '$_indent'
+      'static var title: LocalizedStringResource = "${info.title}"',
+    );
+  }
+
+  /// Writes the static `description` declaration when present.
+  void _writeIntentDescription(StringBuffer buffer, IntentInfo info) {
+    if (info.description == null) return;
+    buffer.writeln(
+      '$_indent'
+      'static var description: IntentDescription =',
+    );
+    final escapedDesc = info.description!.replaceAll('\n', '\\n');
+    buffer.writeln(
+      '$_indent$_indent'
+      'IntentDescription("$escapedDesc")',
+    );
+  }
+
+  /// Writes the `parameterSummary` declaration when present.
+  void _writeParameterSummary(StringBuffer buffer, IntentInfo info) {
+    if (info.parameterSummary == null) return;
+    buffer.writeln();
+    final summaryStr = _interpolateParameterSummary(info.parameterSummary!);
+    buffer.writeln(
+      '${_indent}static var parameterSummary: some ParameterSummary {',
+    );
+    buffer.writeln('$_indent${_indent}Summary("$summaryStr")');
+    buffer.writeln('$_indent}');
+  }
+
+  /// Writes the `@Parameter` declarations when present.
+  void _writeIntentParameters(StringBuffer buffer, IntentInfo info) {
+    if (info.parameters.isEmpty) return;
+    buffer.writeln();
+    for (final param in info.parameters) {
+      _writeParameter(buffer, param);
+    }
+  }
+
+  /// Maps an execution target to its Swift `IntentExecutionTargets` member.
+  String _executionTargetToSwift(IntentExecutionTargetType target) {
+    switch (target) {
+      case IntentExecutionTargetType.main:
+        return '.main';
+      case IntentExecutionTargetType.appIntentsExtension:
+        return '.appIntentsExtension';
+      case IntentExecutionTargetType.widgetKitExtension:
+        return '.widgetKitExtension';
+    }
   }
 
   /// Generates shortcuts provider body without import statement.

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -353,7 +353,9 @@ class SwiftGenerator {
     IntentInfo info,
     String baseIndent,
   ) {
-    buffer.writeln('${baseIndent}let _ = try await FlutterBridge.shared.invoke(');
+    buffer.writeln(
+      '${baseIndent}let _ = try await FlutterBridge.shared.invoke(',
+    );
     buffer.writeln('$baseIndent${_indent}intent: "${info.className}",');
     if (info.parameters.isEmpty) {
       buffer.writeln('$baseIndent${_indent}params: [:]');

--- a/packages/app_intents_codegen/lib/src/models/intent_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/intent_info.dart
@@ -37,6 +37,18 @@ class IntentInfo {
   /// When foreground, both `supportedModes` (iOS 26+) and `openAppWhenRun` are generated.
   final IntentModeType? supportedModes;
 
+  /// Experimental (WWDC26): whether the intent conforms to `LongRunningIntent`.
+  /// Only emitted when the long-running experimental feature is enabled.
+  final bool longRunning;
+
+  /// Experimental (WWDC26): whether the intent conforms to `CancellableIntent`.
+  /// Only emitted when the long-running experimental feature is enabled.
+  final bool cancellable;
+
+  /// Experimental (WWDC26): the targets this intent may execute against.
+  /// When non-empty, generates `allowedExecutionTargets: IntentExecutionTargets`.
+  final List<IntentExecutionTargetType>? executionTargets;
+
   const IntentInfo({
     required this.className,
     required this.identifier,
@@ -49,6 +61,9 @@ class IntentInfo {
     this.resultDialogTemplate,
     this.parameterSummary,
     this.supportedModes,
+    this.longRunning = false,
+    this.cancellable = false,
+    this.executionTargets,
   });
 
   @override
@@ -65,7 +80,10 @@ class IntentInfo {
         urlAction == other.urlAction &&
         resultDialogTemplate == other.resultDialogTemplate &&
         parameterSummary == other.parameterSummary &&
-        supportedModes == other.supportedModes;
+        supportedModes == other.supportedModes &&
+        longRunning == other.longRunning &&
+        cancellable == other.cancellable &&
+        _nullableListEquals(executionTargets, other.executionTargets);
   }
 
   @override
@@ -81,6 +99,9 @@ class IntentInfo {
     resultDialogTemplate,
     parameterSummary,
     supportedModes,
+    longRunning,
+    cancellable,
+    executionTargets == null ? null : Object.hashAll(executionTargets!),
   );
 
   @override
@@ -90,7 +111,8 @@ class IntentInfo {
       'parameters: $parameters, '
       'urlScheme: $urlScheme, urlAction: $urlAction, '
       'resultDialogTemplate: $resultDialogTemplate, parameterSummary: $parameterSummary, '
-      'supportedModes: $supportedModes)';
+      'supportedModes: $supportedModes, longRunning: $longRunning, '
+      'cancellable: $cancellable, executionTargets: $executionTargets)';
 }
 
 /// The implementation language for the intent.
@@ -98,6 +120,11 @@ enum IntentImplementationType { dart, swift, kotlin }
 
 /// The execution mode for the intent.
 enum IntentModeType { background, foreground }
+
+/// Experimental (WWDC26): a process target an intent may execute against.
+///
+/// Maps to members of the Swift `IntentExecutionTargets` option set.
+enum IntentExecutionTargetType { main, appIntentsExtension, widgetKitExtension }
 
 /// Represents analyzed information about an intent parameter.
 class IntentParamInfo {
@@ -178,4 +205,9 @@ bool _listEquals<T>(List<T> a, List<T> b) {
     if (a[i] != b[i]) return false;
   }
   return true;
+}
+
+bool _nullableListEquals<T>(List<T>? a, List<T>? b) {
+  if (a == null || b == null) return a == b;
+  return _listEquals(a, b);
 }

--- a/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
@@ -1,0 +1,119 @@
+import 'package:app_intents_codegen/src/analyzer/intent_analyzer.dart';
+import 'package:app_intents_codegen/src/models/intent_info.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('IntentAnalyzer (WWDC26 experimental fields)', () {
+    late IntentAnalyzer analyzer;
+
+    setUp(() {
+      analyzer = IntentAnalyzer();
+    });
+
+    test('defaults longRunning/cancellable to false and targets to null',
+        () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.greet',
+          title: 'Greet User',
+        )
+        class GreetIntent extends IntentSpecBase {}
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'GreetIntent'));
+
+      expect(result!.longRunning, isFalse);
+      expect(result.cancellable, isFalse);
+      expect(result.executionTargets, isNull);
+    });
+
+    test('parses longRunning and cancellable flags', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.upload',
+          title: 'Upload',
+          longRunning: true,
+          cancellable: true,
+        )
+        class UploadIntent extends IntentSpecBase {}
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'UploadIntent'));
+
+      expect(result!.longRunning, isTrue);
+      expect(result.cancellable, isTrue);
+    });
+
+    test('parses executionTargets list in declared order', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.upload',
+          title: 'Upload',
+          longRunning: true,
+          executionTargets: [
+            IntentExecutionTarget.main,
+            IntentExecutionTarget.widgetKitExtension,
+          ],
+        )
+        class UploadIntent extends IntentSpecBase {}
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'UploadIntent'));
+
+      expect(
+        result!.executionTargets,
+        equals(const [
+          IntentExecutionTargetType.main,
+          IntentExecutionTargetType.widgetKitExtension,
+        ]),
+      );
+    });
+
+    test('rejects longRunning combined with urlScheme', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.upload',
+          title: 'Upload',
+          longRunning: true,
+          urlScheme: 'taskapp',
+        )
+        class UploadIntent extends IntentSpecBase {}
+      ''');
+
+      expect(
+        () => analyzer.analyze(findClass(library, 'UploadIntent')),
+        throwsA(isA<InvalidGenerationSourceError>()),
+      );
+    });
+
+    test('rejects cancellable combined with foreground mode', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.upload',
+          title: 'Upload',
+          cancellable: true,
+          supportedModes: IntentMode.foreground,
+        )
+        class UploadIntent extends IntentSpecBase {}
+      ''');
+
+      expect(
+        () => analyzer.analyze(findClass(library, 'UploadIntent')),
+        throwsA(isA<InvalidGenerationSourceError>()),
+      );
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
@@ -13,9 +13,10 @@ void main() {
       analyzer = IntentAnalyzer();
     });
 
-    test('defaults longRunning/cancellable to false and targets to null',
-        () async {
-      final library = await resolveSource('''
+    test(
+      'defaults longRunning/cancellable to false and targets to null',
+      () async {
+        final library = await resolveSource('''
         import 'package:app_intents_annotations/app_intents_annotations.dart';
 
         @IntentSpec(
@@ -25,12 +26,13 @@ void main() {
         class GreetIntent extends IntentSpecBase {}
       ''');
 
-      final result = analyzer.analyze(findClass(library, 'GreetIntent'));
+        final result = analyzer.analyze(findClass(library, 'GreetIntent'));
 
-      expect(result!.longRunning, isFalse);
-      expect(result.cancellable, isFalse);
-      expect(result.executionTargets, isNull);
-    });
+        expect(result!.longRunning, isFalse);
+        expect(result.cancellable, isFalse);
+        expect(result.executionTargets, isNull);
+      },
+    );
 
     test('parses longRunning and cancellable flags', () async {
       final library = await resolveSource('''

--- a/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
+++ b/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
@@ -1,0 +1,74 @@
+import 'package:app_intents_codegen/src/experimental/experimental_features.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ExperimentalFeature', () {
+    test('fromFlag resolves known tokens and rejects unknown', () {
+      expect(
+        ExperimentalFeature.fromFlag('long-running'),
+        ExperimentalFeature.longRunning,
+      );
+      expect(
+        ExperimentalFeature.fromFlag('app-schema'),
+        ExperimentalFeature.appSchema,
+      );
+      expect(ExperimentalFeature.fromFlag('nope'), isNull);
+    });
+
+    test('allFlags lists every feature token', () {
+      expect(
+        ExperimentalFeature.allFlags,
+        containsAll(<String>['long-running', 'app-schema']),
+      );
+    });
+  });
+
+  group('ExperimentalFeatures', () {
+    test('none disables everything', () {
+      const features = ExperimentalFeatures.none;
+      expect(features.masterEnabled, isFalse);
+      expect(features.anyEnabled, isFalse);
+      expect(features.isEnabled(ExperimentalFeature.longRunning), isFalse);
+      expect(features.isEnabled(ExperimentalFeature.appSchema), isFalse);
+    });
+
+    test('master off ignores selected features', () {
+      const features = ExperimentalFeatures(
+        masterEnabled: false,
+        enabled: {ExperimentalFeature.longRunning},
+      );
+      expect(features.isEnabled(ExperimentalFeature.longRunning), isFalse);
+      expect(features.anyEnabled, isFalse);
+    });
+
+    test('master on with empty set enables all features', () {
+      const features = ExperimentalFeatures(masterEnabled: true);
+      expect(features.isEnabled(ExperimentalFeature.longRunning), isTrue);
+      expect(features.isEnabled(ExperimentalFeature.appSchema), isTrue);
+      expect(features.anyEnabled, isTrue);
+    });
+
+    test('master on with explicit set narrows to listed features', () {
+      const features = ExperimentalFeatures(
+        masterEnabled: true,
+        enabled: {ExperimentalFeature.longRunning},
+      );
+      expect(features.isEnabled(ExperimentalFeature.longRunning), isTrue);
+      expect(features.isEnabled(ExperimentalFeature.appSchema), isFalse);
+    });
+
+    test('value equality is order-independent for the enabled set', () {
+      const a = ExperimentalFeatures(
+        masterEnabled: true,
+        enabled: {ExperimentalFeature.longRunning, ExperimentalFeature.appSchema},
+      );
+      const b = ExperimentalFeatures(
+        masterEnabled: true,
+        enabled: {ExperimentalFeature.appSchema, ExperimentalFeature.longRunning},
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(ExperimentalFeatures.none)));
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
+++ b/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
@@ -60,11 +60,17 @@ void main() {
     test('value equality is order-independent for the enabled set', () {
       const a = ExperimentalFeatures(
         masterEnabled: true,
-        enabled: {ExperimentalFeature.longRunning, ExperimentalFeature.appSchema},
+        enabled: {
+          ExperimentalFeature.longRunning,
+          ExperimentalFeature.appSchema,
+        },
       );
       const b = ExperimentalFeatures(
         masterEnabled: true,
-        enabled: {ExperimentalFeature.appSchema, ExperimentalFeature.longRunning},
+        enabled: {
+          ExperimentalFeature.appSchema,
+          ExperimentalFeature.longRunning,
+        },
       );
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));

--- a/packages/app_intents_codegen/test/generator/swift_generator_experimental_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_experimental_test.dart
@@ -1,0 +1,177 @@
+import 'package:app_intents_codegen/src/experimental/experimental_features.dart';
+import 'package:app_intents_codegen/src/generator/swift_generator.dart';
+import 'package:app_intents_codegen/src/models/intent_info.dart';
+import 'package:test/test.dart';
+
+/// A generator with every WWDC26 experimental feature enabled.
+SwiftGenerator _experimentalGenerator() =>
+    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
+
+IntentInfo _intent({
+  bool longRunning = false,
+  bool cancellable = false,
+  List<IntentExecutionTargetType>? executionTargets,
+  List<IntentParamInfo> parameters = const [],
+}) {
+  return IntentInfo(
+    className: 'UploadPhotoIntent',
+    identifier: 'com.example.uploadPhoto',
+    title: 'Upload Photo',
+    implementation: IntentImplementationType.dart,
+    parameters: parameters,
+    longRunning: longRunning,
+    cancellable: cancellable,
+    executionTargets: executionTargets,
+  );
+}
+
+void main() {
+  group('SwiftGenerator (WWDC26 experimental execution control)', () {
+    group('opt-in gating', () {
+      test('default generator emits no experimental code', () {
+        final stable = const SwiftGenerator();
+        final result = stable.generateAll(intents: [_intent(longRunning: true)]);
+
+        expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+        expect(result, isNot(contains('LongRunningIntent')));
+        expect(result, isNot(contains('performBackgroundTask')));
+        expect(result, contains('struct UploadPhotoIntent: AppIntent {'));
+      });
+
+      test('master on but feature not selected emits no experimental code', () {
+        final generator = const SwiftGenerator(
+          experimental: ExperimentalFeatures(
+            masterEnabled: true,
+            enabled: {ExperimentalFeature.appSchema},
+          ),
+        );
+        final result = generator.generateAll(
+          intents: [_intent(longRunning: true)],
+        );
+
+        expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+        expect(result, isNot(contains('LongRunningIntent')));
+      });
+    });
+
+    group('dual-branch emission', () {
+      test('long-running intent wraps both branches in #if/#else/#endif', () {
+        final result = _experimentalGenerator().generateAll(
+          intents: [_intent(longRunning: true)],
+        );
+
+        // Compilation guard so released-SDK builds fall back to the stable form.
+        expect(result, contains('#if APP_INTENTS_WWDC26'));
+        expect(result, contains('#else'));
+        expect(result, contains('#endif'));
+
+        // Experimental branch: iOS 27, LongRunningIntent, performBackgroundTask.
+        expect(result, contains('@available(iOS 27.0, *)'));
+        expect(
+          result,
+          contains('struct UploadPhotoIntent: AppIntent, LongRunningIntent {'),
+        );
+        expect(result, contains('try await performBackgroundTask {'));
+        expect(result, contains('FlutterBridge.shared.invoke('));
+
+        // Stable branch: plain AppIntent at iOS 17, no LongRunningIntent.
+        expect(result, contains('@available(iOS 17.0, *)'));
+        expect(result, contains('struct UploadPhotoIntent: AppIntent {'));
+
+        // The #else branch must not re-declare the experimental conformance.
+        final elseIndex = result.indexOf('#else');
+        final endifIndex = result.indexOf('#endif');
+        final elseBranch = result.substring(elseIndex, endifIndex);
+        expect(elseBranch, isNot(contains('LongRunningIntent')));
+        expect(elseBranch, isNot(contains('performBackgroundTask')));
+      });
+    });
+
+    group('cancellable', () {
+      test('cancellable-only intent uses withIntentCancellationHandler', () {
+        final result = _experimentalGenerator().generateAll(
+          intents: [_intent(cancellable: true)],
+        );
+
+        // CancellableIntent alone is available from iOS 26.4.
+        expect(result, contains('@available(iOS 26.4, *)'));
+        expect(
+          result,
+          contains('struct UploadPhotoIntent: AppIntent, CancellableIntent {'),
+        );
+        expect(result, contains('try await withIntentCancellationHandler {'));
+        expect(result, contains('} onCancel: { reason in'));
+        expect(result, isNot(contains('performBackgroundTask')));
+      });
+
+      test('long-running + cancellable uses combined performBackgroundTask', () {
+        final result = _experimentalGenerator().generateAll(
+          intents: [_intent(longRunning: true, cancellable: true)],
+        );
+
+        expect(result, contains('@available(iOS 27.0, *)'));
+        expect(
+          result,
+          contains(
+            'struct UploadPhotoIntent: AppIntent, LongRunningIntent, CancellableIntent {',
+          ),
+        );
+        expect(result, contains('try await performBackgroundTask {'));
+        expect(result, contains('} onCancel: { reason in'));
+        expect(result, isNot(contains('withIntentCancellationHandler')));
+      });
+    });
+
+    group('executionTargets', () {
+      test('emits allowedExecutionTargets with mapped members', () {
+        final result = _experimentalGenerator().generateAll(
+          intents: [
+            _intent(
+              longRunning: true,
+              executionTargets: const [
+                IntentExecutionTargetType.main,
+                IntentExecutionTargetType.widgetKitExtension,
+              ],
+            ),
+          ],
+        );
+
+        expect(
+          result,
+          contains(
+            'static var allowedExecutionTargets: IntentExecutionTargets { [.main, .widgetKitExtension] }',
+          ),
+        );
+      });
+
+      test(
+        'executionTargets-only intent keeps the standard background perform()',
+        () {
+          final result = _experimentalGenerator().generateAll(
+            intents: [
+              _intent(
+                executionTargets: const [
+                  IntentExecutionTargetType.appIntentsExtension,
+                ],
+              ),
+            ],
+          );
+
+          // Still experimental (iOS 27 for IntentExecutionTargets) and guarded.
+          expect(result, contains('#if APP_INTENTS_WWDC26'));
+          expect(result, contains('@available(iOS 27.0, *)'));
+          expect(
+            result,
+            contains(
+              'static var allowedExecutionTargets: IntentExecutionTargets { [.appIntentsExtension] }',
+            ),
+          );
+          // No wrapping when neither long-running nor cancellable.
+          expect(result, isNot(contains('performBackgroundTask')));
+          expect(result, isNot(contains('withIntentCancellationHandler')));
+          expect(result, contains('FlutterBridge.shared.invoke('));
+        },
+      );
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/generator/swift_generator_experimental_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_experimental_test.dart
@@ -4,8 +4,9 @@ import 'package:app_intents_codegen/src/models/intent_info.dart';
 import 'package:test/test.dart';
 
 /// A generator with every WWDC26 experimental feature enabled.
-SwiftGenerator _experimentalGenerator() =>
-    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
+SwiftGenerator _experimentalGenerator() => const SwiftGenerator(
+  experimental: ExperimentalFeatures(masterEnabled: true),
+);
 
 IntentInfo _intent({
   bool longRunning = false,
@@ -30,7 +31,9 @@ void main() {
     group('opt-in gating', () {
       test('default generator emits no experimental code', () {
         final stable = const SwiftGenerator();
-        final result = stable.generateAll(intents: [_intent(longRunning: true)]);
+        final result = stable.generateAll(
+          intents: [_intent(longRunning: true)],
+        );
 
         expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
         expect(result, isNot(contains('LongRunningIntent')));

--- a/packages/app_intents_codegen/test/test_utils.dart
+++ b/packages/app_intents_codegen/test/test_utils.dart
@@ -43,6 +43,10 @@ Future<LibraryElement> resolveSource(String source) async {
           final String? urlAction;
           final String? resultDialogTemplate;
           final String? parameterSummary;
+          final IntentMode? supportedModes;
+          final bool longRunning;
+          final bool cancellable;
+          final List<IntentExecutionTarget>? executionTargets;
 
           const IntentSpec({
             required this.identifier,
@@ -53,12 +57,27 @@ Future<LibraryElement> resolveSource(String source) async {
             this.urlAction,
             this.resultDialogTemplate,
             this.parameterSummary,
+            this.supportedModes,
+            this.longRunning = false,
+            this.cancellable = false,
+            this.executionTargets,
           });
         }
 
         enum IntentImplementation {
           dart,
           swift,
+        }
+
+        enum IntentMode {
+          background,
+          foreground,
+        }
+
+        enum IntentExecutionTarget {
+          main,
+          appIntentsExtension,
+          widgetKitExtension,
         }
       ''',
       'app_intents_annotations|lib/src/annotations/intent_param.dart': '''


### PR DESCRIPTION
## 概要

WWDC26 の新 App Intents API を **opt-in（デフォルトOFF）** で出力する機構を導入し、その第1機能として **#52 Intent 実行制御** を end-to-end で実装しました。安定SDK利用者とベータXcode利用者を共存させる、issue #59 の開発方針に沿った実装です。

## フラグ基盤（epic 全体で再利用）

- `ExperimentalFeatures`（`lib/src/experimental/experimental_features.dart`）: master スイッチ + 機能別セット。デフォルトOFFで**既存の安定出力をバイト一致で再現**。
- CLI `generate_swift`: `--experimental-wwdc26`（master）+ `--experimental=long-running,app-schema`（機能別）。
- `SwiftGenerator(experimental:)`: 該当 Intent ごとに**構造体を2本**生成 — `#if APP_INTENTS_WWDC26`（WWDC26版）/ `#else`（安定版）。experimental生成ONでも `APP_INTENTS_WWDC26` 未定義のビルドはコンパイルが通る。

## #52 Intent 実行制御

- `@IntentSpec(longRunning:, cancellable:, executionTargets:)` + `IntentExecutionTarget` enum。
- analyzer が parse し、`longRunning`/`cancellable` と `urlScheme`/foreground の併用を拒否（本質的に background のため）。
- 生成 Swift が `LongRunningIntent` / `CancellableIntent` に準拠し、FlutterBridge invoke を `performBackgroundTask` / `withIntentCancellationHandler` でラップ。`allowedExecutionTargets: IntentExecutionTargets` を出力。

## SDK 照合（Xcode 27 beta `.swiftinterface` で確定）

issue ドラフトの API を実物に補正しました（**WWDC26 API は iOS 26 ではなく iOS 27**）:
- `LongRunningIntent`（iOS 27.0）/ `performBackgroundTask(options:operation:)` + `…onCancel:`（`Self: CancellableIntent` 制約の合体版）
- `CancellableIntent`（iOS 26.4）/ `withIntentCancellationHandler(operation:onCancel:isolation:)` + `IntentCancellationReason`
- `IntentExecutionTargets`（iOS 27.0、OptionSet）= `.main` / `.appIntentsExtension` / `.widgetKitExtension`

## 検証

- codegen **271** + annotations **8** テスト緑（回帰ゼロ、安定出力は不変）
- `dart analyze` クリーン
- **dual-branch `swiftc -typecheck` 緑**（Xcode 27 beta iOS 27 SDK、`-D APP_INTENTS_WWDC26` 有/無の両方）

## スコープ外（フォローアップ）

- #49 App Schema は SDK 調査の結果、entity 生成戦略の変更＋ #50/#53 依存と判明（詳細は #49 にコメント）。`app-schema` 機能別フラグは予約済み。

Refs #59, #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded WWDC26 experimental code generation docs with opt-in details, CLI usage, emission patterns, and verification checklist.

* **New Features**
  * Opt-in experimental WWDC26 code generation via CLI flags.
  * New intent options: longRunning, cancellable, executionTargets.
  * New IntentExecutionTarget enum for specifying execution targets.

* **Public API**
  * Re-exported experimental configuration types for consumers.

* **Tests**
  * Added tests covering experimental feature flags, analyzer validations, and generated Swift output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Closes #52
