### PR TITLE
feat(codegen): App Schema (#49) + @Property semantic indexing (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,13 @@ docs/
   - CLI `generate_swift`: `--experimental-wwdc26` (master) + `--experimental=long-running,app-schema` (per-feature)
   - `@IntentSpec(longRunning:, cancellable:, executionTargets:)` + `IntentExecutionTarget` enum
   - `SwiftGenerator` emits **two struct variants per intent**: WWDC26 form in `#if APP_INTENTS_WWDC26`, stable form in `#else` (so released-SDK builds without the flag still compile)
-  - Verified: 271 codegen + 8 annotation tests green; **dual-branch `swiftc -typecheck` green against Xcode 27 beta iOS 27 SDK** (with and without `-D APP_INTENTS_WWDC26`)
+  - Verified: dual-branch `swiftc -typecheck` green against Xcode 27 beta iOS 27 SDK (with and without `-D APP_INTENTS_WWDC26`)
   - See "WWDC26 Experimental Code Generation" under Code Conventions for the SDK-verified API facts
+- **WWDC26 App Schema (#49) + semantic indexing (#50)**
+  - `@EntitySpec(schema:)` / `@IntentSpec(schema:)` (e.g. `'messages.message'`) → dual-branch `@AppEntity(schema: .messages.message)` / `@AppIntent(schema: .messages.setMessageReadStatus)` gated by the `app-schema` experimental feature (iOS 27). The entity struct, its query and extensions all move to iOS 27 in the `#if` branch.
+  - `@EntityProperty(title:, indexingKey:)` → Swift `@Property(...)`; `indexingKey: 'contentDescription'` emits `@Property(indexingKey: \.contentDescription)` for semantic indexing. **Normal feature (no experimental flag)** gated at `@available(iOS 18.4, *)`.
+  - Entities that expose `@Property` get an explicit initializer (the `@Property`/`EntityProperty` wrapper has **no `init(wrappedValue:)`**), with defaults so the role-only construction in the generated query keeps compiling.
+  - Verified: 286 codegen + 8 annotation tests green; dual-branch `swiftc -typecheck` green for schema × indexed × enumerable × `@Property` combinations (stable @ iOS 18.4, experimental @ iOS 27).
 - `app_intents_annotations`: All annotations defined
   - `@IntentSpec` (with `urlScheme`/`urlAction`, `resultDialogTemplate`, `parameterSummary`)
   - `@IntentParam` (with `entityType` for entity picker, `enumType` for AppEnum parameters)
@@ -280,6 +285,9 @@ the `APP_INTENTS_WWDC26` build flag must still get compiling (stable) Swift.
 - `IntentExecutionTargets` — **iOS 27.0**; OptionSet with `.main` / `.appIntentsExtension`
   / `.widgetKitExtension` (not `.widget`); used via `static var allowedExecutionTargets`.
 - `ProgressReportingIntent.progress` is **extension-provided** (no member to implement).
+- **App Schema (#49)** macros `@AppEntity(schema:)` / `@AppIntent(schema:)` / `@AppEnum(schema:)` are **iOS 27** external macros (`AppIntentsMacros`). The macro is lenient: it adds the conformance (`@attached(extension, conformances: AppEntity, …)`) and tolerates a minimal entity body + a redundant explicit `: AppEntity`. Schema-specific properties are optional/synthesized, so an existing generated entity compiles by just prefixing the macro. Schema accessor form is `.<domain>.<schema>` (e.g. `.messages.message`, `.messages.setMessageReadStatus`).
+- **Semantic indexing (#50)**: `@Property(indexingKey:)` takes a `PartialKeyPath<CSSearchableItemAttributeSet>` (e.g. `\.contentDescription`) and is **iOS 18.4** (stable SDK, not iOS 27) — so it ships as a normal `@available(iOS 18.4, *)` feature, not behind `#if`. `@Property` ≡ `EntityProperty` (typealias); its bare `init()` is `@available(*, unavailable)`, so always emit at least `@Property(title:)`.
+- `IndexedEntityQuery` (re-indexing: `reindexEntities`/`reindexAllEntities`) is iOS 27 (deferred). `@ComputedProperty`/`@DeferredProperty` are iOS 26 macros (deferred).
 
 **How to verify (the load-bearing check)**: golden/unit tests only assert "the strings
 I emitted came out"; they pass while emitting Swift that won't compile. Always

--- a/packages/app_intents_annotations/lib/src/annotations/entity_params.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/entity_params.dart
@@ -22,3 +22,25 @@ class EntityImage {
 class EntityDefaultQuery {
   const EntityDefaultQuery();
 }
+
+/// Marks an entity field to be exposed to the system as a Swift `@Property`.
+///
+/// Use this for semantic properties beyond the id/title/subtitle/image roles —
+/// for example a message body or note that Spotlight and Apple Intelligence
+/// should be able to search.
+///
+/// - [title]: optional human-readable title (`@Property(title: "Body")`).
+/// - [indexingKey]: a `CSSearchableItemAttributeSet` key path name (without the
+///   leading `\.`), e.g. `'contentDescription'`. When set, generates
+///   `@Property(indexingKey: \.contentDescription)` for semantic indexing
+///   (iOS 18.4+). The generated entity gets an explicit initializer because the
+///   `@Property` wrapper has no `init(wrappedValue:)`.
+class EntityProperty {
+  /// An optional human-readable title for the property.
+  final String? title;
+
+  /// A `CSSearchableItemAttributeSet` key path name for semantic indexing.
+  final String? indexingKey;
+
+  const EntityProperty({this.title, this.indexingKey});
+}

--- a/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
@@ -63,6 +63,16 @@ class EntitySpec {
   /// must be available.
   final String? persistedCacheKey;
 
+  /// **Experimental (WWDC26, iOS 27+).** The App Schema this entity conforms to,
+  /// as a dotted `domain.schema` path (e.g. `'messages.message'`).
+  ///
+  /// When experimental code generation is enabled, the generated Swift adds the
+  /// `@AppEntity(schema: .messages.message)` macro so the entity is described in
+  /// a vocabulary Siri/Apple Intelligence already understands. Emitted in a
+  /// `#if APP_INTENTS_WWDC26` block with a stable `@AppEntity`-only fallback.
+  /// Has no effect unless experimental generation is enabled.
+  final String? schema;
+
   const EntitySpec({
     required this.identifier,
     required this.title,
@@ -72,5 +82,6 @@ class EntitySpec {
     this.indexed = false,
     this.enumerable = false,
     this.persistedCacheKey,
+    this.schema,
   });
 }

--- a/packages/app_intents_annotations/lib/src/annotations/intent_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/intent_spec.dart
@@ -79,6 +79,15 @@ class IntentSpec {
   /// unless experimental generation is enabled.
   final List<IntentExecutionTarget>? executionTargets;
 
+  /// **Experimental (WWDC26, iOS 27+).** The App Schema this intent conforms to,
+  /// as a dotted `domain.schema` path (e.g. `'messages.setMessageReadStatus'`).
+  ///
+  /// When experimental code generation is enabled, the generated Swift adds the
+  /// `@AppIntent(schema: .messages.setMessageReadStatus)` macro. Emitted in a
+  /// `#if APP_INTENTS_WWDC26` block with a stable `AppIntent`-only fallback. Has
+  /// no effect unless experimental generation is enabled.
+  final String? schema;
+
   const IntentSpec({
     required this.identifier,
     required this.title,
@@ -92,6 +101,7 @@ class IntentSpec {
     this.longRunning = false,
     this.cancellable = false,
     this.executionTargets,
+    this.schema,
   });
 }
 

--- a/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
@@ -34,6 +34,11 @@ const _entityDefaultQueryChecker = TypeChecker.fromUrl(
   'package:app_intents_annotations/src/annotations/entity_params.dart#EntityDefaultQuery',
 );
 
+/// Type checker for EntityProperty annotation.
+const _entityPropertyChecker = TypeChecker.fromUrl(
+  'package:app_intents_annotations/src/annotations/entity_params.dart#EntityProperty',
+);
+
 /// Type checker for EntitySpecBase base class.
 const _entitySpecBaseChecker = TypeChecker.fromUrl(
   'package:app_intents_annotations/src/bases/entity_spec_base.dart#EntitySpecBase',
@@ -71,6 +76,7 @@ class EntityAnalyzer {
     final persistedCacheKey = annotation
         .getField('persistedCacheKey')
         ?.toStringValue();
+    final schema = annotation.getField('schema')?.toStringValue();
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -106,6 +112,7 @@ class EntityAnalyzer {
       indexed: indexed,
       enumerable: enumerable,
       persistedCacheKey: persistedCacheKey,
+      schema: schema,
     );
   }
 
@@ -126,13 +133,22 @@ class EntityAnalyzer {
 
     for (final field in element.fields) {
       final role = _determinePropertyRole(field);
-      if (role == EntityPropertyRole.none) continue;
+      final propAnnotation = _entityPropertyChecker.firstAnnotationOfExact(
+        field,
+      );
+      final exposeAsProperty = propAnnotation != null;
+
+      // Include role-annotated fields and @EntityProperty fields; skip the rest.
+      if (role == EntityPropertyRole.none && !exposeAsProperty) continue;
 
       properties.add(
         EntityPropertyInfo(
           fieldName: field.name!,
           dartType: field.type.getDisplayString(),
           role: role,
+          exposeAsProperty: exposeAsProperty,
+          propertyTitle: propAnnotation?.getField('title')?.toStringValue(),
+          indexingKey: propAnnotation?.getField('indexingKey')?.toStringValue(),
         ),
       );
     }

--- a/packages/app_intents_codegen/lib/src/analyzer/intent_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/intent_analyzer.dart
@@ -57,6 +57,7 @@ class IntentAnalyzer {
     final executionTargets = _parseExecutionTargets(
       annotation.getField('executionTargets'),
     );
+    final schema = annotation.getField('schema')?.toStringValue();
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -100,6 +101,7 @@ class IntentAnalyzer {
       longRunning: longRunning,
       cancellable: cancellable,
       executionTargets: executionTargets,
+      schema: schema,
     );
   }
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -1,3 +1,5 @@
+import 'package:source_gen/source_gen.dart';
+
 import '../experimental/experimental_features.dart';
 import '../models/entity_info.dart';
 import '../models/enum_info.dart';
@@ -720,23 +722,67 @@ class SwiftGenerator {
   /// receive type-appropriate defaults so callers that only pass the role
   /// fields still compile.
   void _writeEntityInit(StringBuffer buffer, EntityInfo info) {
-    final params = info.properties.map((prop) {
-      final swiftType = dartTypeToSwiftType(prop.dartType);
-      if (prop.exposeAsProperty) {
-        return '${prop.fieldName}: $swiftType = ${_defaultForSwiftType(swiftType)}';
-      }
-      return '${prop.fieldName}: $swiftType';
-    }).join(', ');
+    // The initializer's parameter order MUST match the construction call site
+    // (`_writeEntityDictMapping`), which lists role fields first
+    // (id, title, subtitle, image) then exposed properties. Swift requires the
+    // labeled arguments a caller *does* provide to appear in declaration order
+    // even when the omitted ones have defaults, so emitting parameters in Dart
+    // field-declaration order would produce non-compiling Swift whenever the
+    // field order differs from the role order.
+    final ordered = _initOrderedProperties(info);
+    final params = ordered
+        .map((prop) {
+          final swiftType = dartTypeToSwiftType(prop.dartType);
+          if (prop.exposeAsProperty) {
+            return '${prop.fieldName}: $swiftType = '
+                '${_defaultForSwiftType(swiftType, prop.fieldName)}';
+          }
+          return '${prop.fieldName}: $swiftType';
+        })
+        .join(', ');
     buffer.writeln('${_indent}init($params) {');
-    for (final prop in info.properties) {
-      buffer.writeln('$_indent${_indent}self.${prop.fieldName} = ${prop.fieldName}');
+    for (final prop in ordered) {
+      buffer.writeln(
+        '$_indent${_indent}self.${prop.fieldName} = ${prop.fieldName}',
+      );
     }
     buffer.writeln('$_indent}');
   }
 
-  /// A literal default value for a Swift type, used for exposed-property init
-  /// parameters so role-only construction keeps compiling.
-  String _defaultForSwiftType(String swiftType) {
+  /// Properties in the order the generated initializer and every construction
+  /// call site list them: the role fields first (id, title, subtitle, image),
+  /// then exposed `@EntityProperty` fields in declaration order. Mirrors the
+  /// argument order built in [_writeEntityDictMapping] so the two cannot drift.
+  List<EntityPropertyInfo> _initOrderedProperties(EntityInfo info) {
+    final ordered = <EntityPropertyInfo>[];
+    for (final role in const [
+      EntityPropertyRole.id,
+      EntityPropertyRole.title,
+      EntityPropertyRole.subtitle,
+      EntityPropertyRole.image,
+    ]) {
+      final prop = info.properties.where((p) => p.role == role).firstOrNull;
+      if (prop != null) ordered.add(prop);
+    }
+    // `_extractProperties` keeps only role-annotated or exposed fields, so every
+    // remaining (role == none) property is an exposed @EntityProperty and is
+    // given a default below — the call site may safely omit it.
+    ordered.addAll(
+      info.properties.where((p) => p.role == EntityPropertyRole.none),
+    );
+    return ordered;
+  }
+
+  /// A literal default value for an exposed property's Swift type, used so a
+  /// construction call site that only passes the role fields (and exposed
+  /// String properties) still compiles.
+  ///
+  /// Throws for types that have no synthesizable default — those cannot be
+  /// exposed via `@EntityProperty`. Note: non-String exposed properties (e.g.
+  /// `Date`) compile via this default but are not populated from the cached
+  /// dict (the query reads only String properties), so they always take the
+  /// default value at construction.
+  String _defaultForSwiftType(String swiftType, String fieldName) {
     if (swiftType.endsWith('?')) return 'nil';
     switch (swiftType) {
       case 'Int':
@@ -746,8 +792,16 @@ class SwiftGenerator {
       case 'Bool':
         return 'false';
       case 'String':
-      default:
         return '""';
+      case 'Date':
+        return 'Date()';
+      default:
+        throw InvalidGenerationSourceError(
+          'Cannot expose entity property `$fieldName` of Swift type '
+          '`$swiftType` via @EntityProperty: no default value can be '
+          'synthesized for the generated initializer. Expose only '
+          'String/int/double/bool/DateTime (or their nullable forms).',
+        );
     }
   }
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -377,11 +377,12 @@ class SwiftGenerator {
   /// Writes the experimental perform() that wraps the background invoke in
   /// `performBackgroundTask` and/or `withIntentCancellationHandler`.
   ///
-  /// An intent that only restricts `executionTargets` (without long-running or
-  /// cancellable) keeps the standard background perform().
+  /// An intent that only restricts `executionTargets` or conforms to a schema
+  /// (without long-running or cancellable) keeps its standard perform() for the
+  /// configured execution mode.
   void _writeExperimentalPerformMethod(StringBuffer buffer, IntentInfo info) {
     if (!info.longRunning && !info.cancellable) {
-      _writeFlutterBridgePerformMethod(buffer, info);
+      _writePerformMethod(buffer, info);
       return;
     }
 
@@ -573,7 +574,7 @@ class SwiftGenerator {
 
     // Import statements
     buffer.writeln('import AppIntents');
-    if (info.indexed) {
+    if (info.indexed || info.hasIndexingKeys) {
       buffer.writeln('import CoreSpotlight');
     }
     if (info.effectiveCacheKey != null) {
@@ -588,11 +589,63 @@ class SwiftGenerator {
   }
 
   void _generateEntityBody(StringBuffer buffer, EntityInfo info) {
-    // Availability and struct declaration
-    buffer.writeln('@available(iOS 17.0, *)');
+    if (_usesExperimentalEntitySchema(info)) {
+      // App Schema (#49) is iOS 27+: the entity, its query and extensions all
+      // move to iOS 27 in the experimental branch. The #else branch keeps the
+      // stable form so released-SDK builds without the flag still compile.
+      buffer.writeln('#if APP_INTENTS_WWDC26');
+      _writeEntityAndQuery(
+        buffer,
+        info,
+        availability: 'iOS 27.0',
+        indexedAvailability: 'iOS 27.0',
+        schemaMacro: '@AppEntity(schema: .${info.schema})',
+      );
+      buffer.writeln();
+      buffer.writeln('#else');
+      _writeEntityAndQuery(
+        buffer,
+        info,
+        availability: _stableEntityAvailability(info),
+        indexedAvailability: 'iOS 26.0',
+      );
+      buffer.writeln();
+      buffer.write('#endif');
+    } else {
+      _writeEntityAndQuery(
+        buffer,
+        info,
+        availability: _stableEntityAvailability(info),
+        indexedAvailability: 'iOS 26.0',
+      );
+    }
+  }
+
+  /// Whether [info] should emit the `@AppEntity(schema:)` macro.
+  bool _usesExperimentalEntitySchema(EntityInfo info) =>
+      experimental.isEnabled(ExperimentalFeature.appSchema) &&
+      info.schema != null;
+
+  /// Stable-SDK availability for an entity. Bumped to iOS 18.4 when any property
+  /// uses semantic `indexingKey` (the `@Property(indexingKey:)` init is 18.4+).
+  String _stableEntityAvailability(EntityInfo info) =>
+      info.hasIndexingKeys ? 'iOS 18.4' : 'iOS 17.0';
+
+  /// Emits the entity struct, its query struct and any extensions at the given
+  /// availability, optionally prefixing the struct with an App Schema macro.
+  void _writeEntityAndQuery(
+    StringBuffer buffer,
+    EntityInfo info, {
+    required String availability,
+    required String indexedAvailability,
+    String? schemaMacro,
+  }) {
+    buffer.writeln('@available($availability, *)');
+    if (schemaMacro != null) {
+      buffer.writeln(schemaMacro);
+    }
     buffer.writeln('struct ${info.className}: AppEntity {');
 
-    // Type display representation
     buffer.writeln(
       '$_indent'
       'static var typeDisplayRepresentation: TypeDisplayRepresentation =',
@@ -603,36 +656,98 @@ class SwiftGenerator {
     );
     buffer.writeln();
 
-    // Default query
     buffer.writeln(
       '${_indent}static var defaultQuery = ${info.className}Query()',
     );
     buffer.writeln();
 
-    // Properties
-    for (final prop in info.properties) {
-      final swiftType = dartTypeToSwiftType(prop.dartType);
-      buffer.writeln('${_indent}var ${prop.fieldName}: $swiftType');
+    _writeEntityProperties(buffer, info);
+
+    // The @Property wrapper has no init(wrappedValue:), so an entity that
+    // exposes properties needs an explicit initializer; exposed properties get
+    // defaults so the role-only construction in the query keeps compiling.
+    if (info.hasExposedProperties) {
+      buffer.writeln();
+      _writeEntityInit(buffer, info);
     }
 
-    // Display representation
     buffer.writeln();
     _writeDisplayRepresentation(buffer, info);
 
     buffer.writeln('}');
     buffer.writeln();
 
-    // Generate query struct
-    _writeQueryStruct(buffer, info);
+    _writeQueryStruct(buffer, info, availability);
 
-    // Generate EnumerableEntityQuery extension
     if (info.enumerable) {
-      _writeEnumerableQueryExtension(buffer, info);
+      _writeEnumerableQueryExtension(buffer, info, availability);
     }
 
-    // Generate IndexedEntity extension
     if (info.indexed) {
-      _writeIndexedEntityExtension(buffer, info);
+      _writeIndexedEntityExtension(buffer, info, indexedAvailability);
+    }
+  }
+
+  /// Writes the entity's stored properties, using `@Property(...)` for fields
+  /// marked with `@EntityProperty`.
+  void _writeEntityProperties(StringBuffer buffer, EntityInfo info) {
+    for (final prop in info.properties) {
+      final swiftType = dartTypeToSwiftType(prop.dartType);
+      if (prop.exposeAsProperty) {
+        buffer.writeln('$_indent${_propertyAttribute(prop)}');
+      }
+      buffer.writeln('${_indent}var ${prop.fieldName}: $swiftType');
+    }
+  }
+
+  /// Builds the `@Property(...)` attribute for an exposed property. Falls back
+  /// to `@Property(title:)` (the bare `@Property` init is unavailable).
+  String _propertyAttribute(EntityPropertyInfo prop) {
+    final args = <String>[];
+    if (prop.propertyTitle != null) {
+      args.add('title: "${prop.propertyTitle}"');
+    }
+    if (prop.indexingKey != null) {
+      args.add('indexingKey: \\.${prop.indexingKey}');
+    }
+    if (args.isEmpty) {
+      args.add('title: "${prop.fieldName}"');
+    }
+    return '@Property(${args.join(', ')})';
+  }
+
+  /// Writes an explicit initializer covering all properties. Exposed properties
+  /// receive type-appropriate defaults so callers that only pass the role
+  /// fields still compile.
+  void _writeEntityInit(StringBuffer buffer, EntityInfo info) {
+    final params = info.properties.map((prop) {
+      final swiftType = dartTypeToSwiftType(prop.dartType);
+      if (prop.exposeAsProperty) {
+        return '${prop.fieldName}: $swiftType = ${_defaultForSwiftType(swiftType)}';
+      }
+      return '${prop.fieldName}: $swiftType';
+    }).join(', ');
+    buffer.writeln('${_indent}init($params) {');
+    for (final prop in info.properties) {
+      buffer.writeln('$_indent${_indent}self.${prop.fieldName} = ${prop.fieldName}');
+    }
+    buffer.writeln('$_indent}');
+  }
+
+  /// A literal default value for a Swift type, used for exposed-property init
+  /// parameters so role-only construction keeps compiling.
+  String _defaultForSwiftType(String swiftType) {
+    if (swiftType.endsWith('?')) return 'nil';
+    switch (swiftType) {
+      case 'Int':
+        return '0';
+      case 'Double':
+        return '0';
+      case 'Bool':
+        return 'false';
+      case 'String':
+      default:
+        return '""';
     }
   }
 
@@ -701,7 +816,11 @@ class SwiftGenerator {
   }
 
   /// Writes the entity query struct with FlutterBridge integration.
-  void _writeQueryStruct(StringBuffer buffer, EntityInfo info) {
+  void _writeQueryStruct(
+    StringBuffer buffer,
+    EntityInfo info, [
+    String availability = 'iOS 17.0',
+  ]) {
     final idProp = info.properties
         .where((p) => p.role == EntityPropertyRole.id)
         .firstOrNull;
@@ -717,7 +836,7 @@ class SwiftGenerator {
 
     final cacheKey = info.effectiveCacheKey;
 
-    buffer.writeln('@available(iOS 17.0, *)');
+    buffer.writeln('@available($availability, *)');
     buffer.writeln('struct ${info.className}Query: EntityQuery {');
 
     if (cacheKey != null) {
@@ -905,6 +1024,20 @@ class SwiftGenerator {
       );
     }
 
+    // Exposed @Property string fields (role: none) are read from the dict so
+    // semantic content is populated; other types fall back to the init default.
+    final exposedStringProps = info.properties.where(
+      (p) =>
+          p.exposeAsProperty &&
+          p.role == EntityPropertyRole.none &&
+          (p.dartType == 'String' || p.dartType == 'String?'),
+    );
+    for (final prop in exposedStringProps) {
+      buffer.writeln(
+        '$_indent$_indent${_indent}let ${prop.fieldName} = dict["${prop.fieldName}"] as? String',
+      );
+    }
+
     // Build initializer
     final initParts = <String>['$id: $id', '$title: $title'];
     if (subtitleProp != null) {
@@ -913,15 +1046,25 @@ class SwiftGenerator {
     if (imageProp != null) {
       initParts.add('${imageProp.fieldName}: ${imageProp.fieldName}');
     }
+    for (final prop in exposedStringProps) {
+      final value = prop.dartType.endsWith('?')
+          ? prop.fieldName
+          : '${prop.fieldName} ?? ""';
+      initParts.add('${prop.fieldName}: $value');
+    }
     buffer.writeln(
       '$_indent$_indent${_indent}return ${info.className}(${initParts.join(', ')})',
     );
   }
 
   /// Writes EnumerableEntityQuery extension.
-  void _writeEnumerableQueryExtension(StringBuffer buffer, EntityInfo info) {
+  void _writeEnumerableQueryExtension(
+    StringBuffer buffer,
+    EntityInfo info, [
+    String availability = 'iOS 17.0',
+  ]) {
     buffer.writeln();
-    buffer.writeln('@available(iOS 17.0, *)');
+    buffer.writeln('@available($availability, *)');
     buffer.writeln('extension ${info.className}Query: EnumerableEntityQuery {');
     buffer.writeln(
       '${_indent}func allEntities() async throws -> [${info.className}] {',
@@ -932,13 +1075,17 @@ class SwiftGenerator {
   }
 
   /// Writes IndexedEntity extension with attributeSet.
-  void _writeIndexedEntityExtension(StringBuffer buffer, EntityInfo info) {
+  void _writeIndexedEntityExtension(
+    StringBuffer buffer,
+    EntityInfo info, [
+    String availability = 'iOS 26.0',
+  ]) {
     final titleProp = info.properties
         .where((p) => p.role == EntityPropertyRole.title)
         .firstOrNull;
 
     buffer.writeln();
-    buffer.writeln('@available(iOS 26.0, *)');
+    buffer.writeln('@available($availability, *)');
     buffer.writeln('extension ${info.className}: IndexedEntity {');
     buffer.writeln(
       '${_indent}var attributeSet: CSSearchableItemAttributeSet {',
@@ -1003,7 +1150,7 @@ class SwiftGenerator {
         entities.any((e) => e.effectiveCacheKey != null)) {
       buffer.writeln('import app_intents');
     }
-    if (entities.any((e) => e.indexed)) {
+    if (entities.any((e) => e.indexed || e.hasIndexingKeys)) {
       buffer.writeln('import CoreSpotlight');
     }
     buffer.writeln();
@@ -1044,7 +1191,7 @@ class SwiftGenerator {
   /// that build against a released SDK (without the `APP_INTENTS_WWDC26` flag)
   /// still compile.
   void _generateIntentBody(StringBuffer buffer, IntentInfo info) {
-    if (_usesExperimentalExecution(info)) {
+    if (_usesExperimentalIntent(info)) {
       buffer.writeln('#if APP_INTENTS_WWDC26');
       _generateExperimentalIntentBody(buffer, info);
       buffer.writeln();
@@ -1057,6 +1204,11 @@ class SwiftGenerator {
     }
   }
 
+  /// Whether [info] uses any experimental WWDC26 feature (execution control or
+  /// App Schema), which triggers dual-branch emission.
+  bool _usesExperimentalIntent(IntentInfo info) =>
+      _usesExperimentalExecution(info) || _usesExperimentalSchema(info);
+
   /// Whether [info] should emit the experimental WWDC26 execution-control form.
   ///
   /// Requires both the opt-in `long-running` feature to be enabled and the
@@ -1067,6 +1219,12 @@ class SwiftGenerator {
         info.cancellable ||
         (info.executionTargets != null && info.executionTargets!.isNotEmpty);
   }
+
+  /// Whether [info] should emit the `@AppIntent(schema:)` macro (app-schema
+  /// feature enabled and a schema declared).
+  bool _usesExperimentalSchema(IntentInfo info) =>
+      experimental.isEnabled(ExperimentalFeature.appSchema) &&
+      info.schema != null;
 
   /// Generates the stable (released-SDK) intent struct.
   void _generateStableIntentBody(StringBuffer buffer, IntentInfo info) {
@@ -1106,18 +1264,25 @@ class SwiftGenerator {
   void _generateExperimentalIntentBody(StringBuffer buffer, IntentInfo info) {
     final hasExecutionTargets =
         info.executionTargets != null && info.executionTargets!.isNotEmpty;
+    final hasSchema = _usesExperimentalSchema(info);
 
     final conformances = <String>['AppIntent'];
     if (info.longRunning) conformances.add('LongRunningIntent');
     if (info.cancellable) conformances.add('CancellableIntent');
 
-    // LongRunningIntent and IntentExecutionTargets are iOS 27+; CancellableIntent
-    // on its own is iOS 26.4+.
-    final minVersion = (info.longRunning || hasExecutionTargets)
+    // LongRunningIntent, IntentExecutionTargets and App Schema are iOS 27+;
+    // CancellableIntent on its own is iOS 26.4+.
+    final minVersion = (info.longRunning || hasExecutionTargets || hasSchema)
         ? '27.0'
         : '26.4';
 
     buffer.writeln('@available(iOS $minVersion, *)');
+    // The @AppIntent(schema:) macro adds the AppIntent conformance itself, but
+    // the explicit ": AppIntent" is redundant-and-OK and keeps the stable/
+    // experimental structs structurally identical.
+    if (hasSchema) {
+      buffer.writeln('@AppIntent(schema: .${info.schema})');
+    }
     buffer.writeln('struct ${info.className}: ${conformances.join(', ')} {');
 
     _writeIntentTitle(buffer, info);

--- a/packages/app_intents_codegen/lib/src/models/entity_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/entity_info.dart
@@ -166,8 +166,14 @@ class EntityPropertyInfo {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(fieldName, dartType, role, exposeAsProperty, propertyTitle, indexingKey);
+  int get hashCode => Object.hash(
+    fieldName,
+    dartType,
+    role,
+    exposeAsProperty,
+    propertyTitle,
+    indexingKey,
+  );
 
   @override
   String toString() =>

--- a/packages/app_intents_codegen/lib/src/models/entity_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/entity_info.dart
@@ -38,6 +38,12 @@ class EntityInfo {
   /// `app_intents.entities.<identifier>` is used.
   final String? persistedCacheKey;
 
+  /// Experimental (WWDC26): the App Schema this entity conforms to, as a dotted
+  /// `domain.schema` path (e.g. `messages.message`). When set and the
+  /// `app-schema` experimental feature is enabled, the generated Swift adds the
+  /// `@AppEntity(schema:)` macro (dual-branch).
+  final String? schema;
+
   const EntityInfo({
     required this.className,
     required this.identifier,
@@ -50,7 +56,16 @@ class EntityInfo {
     this.indexed = false,
     this.enumerable = false,
     this.persistedCacheKey,
+    this.schema,
   });
+
+  /// Whether any property is exposed as a Swift `@Property`. Such entities need
+  /// an explicit initializer (the `@Property` wrapper has no `init(wrappedValue:)`).
+  bool get hasExposedProperties => properties.any((p) => p.exposeAsProperty);
+
+  /// Whether any exposed property uses semantic `indexingKey` (iOS 18.4+).
+  bool get hasIndexingKeys =>
+      properties.any((p) => p.exposeAsProperty && p.indexingKey != null);
 
   /// Returns the effective cache key to use for App Group fallback, or null
   /// when no fallback should be generated.
@@ -79,6 +94,7 @@ class EntityInfo {
         indexed == other.indexed &&
         enumerable == other.enumerable &&
         persistedCacheKey == other.persistedCacheKey &&
+        schema == other.schema &&
         _listEquals(properties, other.properties);
   }
 
@@ -94,6 +110,7 @@ class EntityInfo {
     indexed,
     enumerable,
     persistedCacheKey,
+    schema,
     Object.hashAll(properties),
   );
 
@@ -102,7 +119,7 @@ class EntityInfo {
       'EntityInfo(className: $className, identifier: $identifier, title: $title, '
       'pluralTitle: $pluralTitle, description: $description, modelType: $modelType, '
       'displayImageName: $displayImageName, indexed: $indexed, enumerable: $enumerable, '
-      'persistedCacheKey: $persistedCacheKey, properties: $properties)';
+      'persistedCacheKey: $persistedCacheKey, schema: $schema, properties: $properties)';
 }
 
 /// Represents analyzed information about an entity property.
@@ -116,10 +133,24 @@ class EntityPropertyInfo {
   /// The role of this property in the entity.
   final EntityPropertyRole role;
 
+  /// Experimental (WWDC26 / #50): whether to emit this field as a Swift
+  /// `@Property(...)` exposed to the system (Spotlight / Apple Intelligence).
+  final bool exposeAsProperty;
+
+  /// The `@Property(title:)` value, when [exposeAsProperty] is true.
+  final String? propertyTitle;
+
+  /// The `CSSearchableItemAttributeSet` key path name (without leading `\.`) for
+  /// `@Property(indexingKey:)` semantic indexing (iOS 18.4+).
+  final String? indexingKey;
+
   const EntityPropertyInfo({
     required this.fieldName,
     required this.dartType,
     required this.role,
+    this.exposeAsProperty = false,
+    this.propertyTitle,
+    this.indexingKey,
   });
 
   @override
@@ -128,15 +159,21 @@ class EntityPropertyInfo {
     if (other is! EntityPropertyInfo) return false;
     return fieldName == other.fieldName &&
         dartType == other.dartType &&
-        role == other.role;
+        role == other.role &&
+        exposeAsProperty == other.exposeAsProperty &&
+        propertyTitle == other.propertyTitle &&
+        indexingKey == other.indexingKey;
   }
 
   @override
-  int get hashCode => Object.hash(fieldName, dartType, role);
+  int get hashCode =>
+      Object.hash(fieldName, dartType, role, exposeAsProperty, propertyTitle, indexingKey);
 
   @override
   String toString() =>
-      'EntityPropertyInfo(fieldName: $fieldName, dartType: $dartType, role: $role)';
+      'EntityPropertyInfo(fieldName: $fieldName, dartType: $dartType, role: $role, '
+      'exposeAsProperty: $exposeAsProperty, propertyTitle: $propertyTitle, '
+      'indexingKey: $indexingKey)';
 }
 
 /// The role of an entity property.

--- a/packages/app_intents_codegen/lib/src/models/intent_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/intent_info.dart
@@ -49,6 +49,11 @@ class IntentInfo {
   /// When non-empty, generates `allowedExecutionTargets: IntentExecutionTargets`.
   final List<IntentExecutionTargetType>? executionTargets;
 
+  /// Experimental (WWDC26): the App Schema this intent conforms to, as a dotted
+  /// `domain.schema` path (e.g. `messages.setMessageReadStatus`). When set and
+  /// the `app-schema` feature is enabled, adds the `@AppIntent(schema:)` macro.
+  final String? schema;
+
   const IntentInfo({
     required this.className,
     required this.identifier,
@@ -64,6 +69,7 @@ class IntentInfo {
     this.longRunning = false,
     this.cancellable = false,
     this.executionTargets,
+    this.schema,
   });
 
   @override
@@ -83,6 +89,7 @@ class IntentInfo {
         supportedModes == other.supportedModes &&
         longRunning == other.longRunning &&
         cancellable == other.cancellable &&
+        schema == other.schema &&
         _nullableListEquals(executionTargets, other.executionTargets);
   }
 
@@ -101,6 +108,7 @@ class IntentInfo {
     supportedModes,
     longRunning,
     cancellable,
+    schema,
     executionTargets == null ? null : Object.hashAll(executionTargets!),
   );
 
@@ -112,7 +120,8 @@ class IntentInfo {
       'urlScheme: $urlScheme, urlAction: $urlAction, '
       'resultDialogTemplate: $resultDialogTemplate, parameterSummary: $parameterSummary, '
       'supportedModes: $supportedModes, longRunning: $longRunning, '
-      'cancellable: $cancellable, executionTargets: $executionTargets)';
+      'cancellable: $cancellable, executionTargets: $executionTargets, '
+      'schema: $schema)';
 }
 
 /// The implementation language for the intent.

--- a/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
@@ -1,0 +1,86 @@
+import 'package:app_intents_codegen/src/analyzer/entity_analyzer.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('EntityAnalyzer (WWDC26 #49 schema / #50 @EntityProperty)', () {
+    late EntityAnalyzer analyzer;
+
+    setUp(() {
+      analyzer = EntityAnalyzer();
+    });
+
+    test('parses schema field', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EntitySpec(
+          identifier: 'com.example.message',
+          title: 'Message',
+          pluralTitle: 'Messages',
+          schema: 'messages.message',
+        )
+        class MessageEntity extends EntitySpecBase {
+          @EntityId()
+          final String id = '';
+          @EntityTitle()
+          final String title = '';
+        }
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'MessageEntity'));
+      expect(result!.schema, equals('messages.message'));
+    });
+
+    test('schema defaults to null', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EntitySpec(
+          identifier: 'com.example.message',
+          title: 'Message',
+          pluralTitle: 'Messages',
+        )
+        class MessageEntity extends EntitySpecBase {
+          @EntityId()
+          final String id = '';
+          @EntityTitle()
+          final String title = '';
+        }
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'MessageEntity'));
+      expect(result!.schema, isNull);
+    });
+
+    test('parses @EntityProperty with title and indexingKey', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EntitySpec(
+          identifier: 'com.example.note',
+          title: 'Note',
+          pluralTitle: 'Notes',
+        )
+        class NoteEntity extends EntitySpecBase {
+          @EntityId()
+          final String id = '';
+          @EntityTitle()
+          final String title = '';
+          @EntityProperty(title: 'Body', indexingKey: 'contentDescription')
+          final String body = '';
+        }
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'NoteEntity'));
+      final bodyProp = result!.properties.firstWhere((p) => p.fieldName == 'body');
+
+      expect(bodyProp.exposeAsProperty, isTrue);
+      expect(bodyProp.propertyTitle, equals('Body'));
+      expect(bodyProp.indexingKey, equals('contentDescription'));
+      expect(result.hasExposedProperties, isTrue);
+      expect(result.hasIndexingKeys, isTrue);
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
@@ -74,7 +74,9 @@ void main() {
       ''');
 
       final result = analyzer.analyze(findClass(library, 'NoteEntity'));
-      final bodyProp = result!.properties.firstWhere((p) => p.fieldName == 'body');
+      final bodyProp = result!.properties.firstWhere(
+        (p) => p.fieldName == 'body',
+      );
 
       expect(bodyProp.exposeAsProperty, isTrue);
       expect(bodyProp.propertyTitle, equals('Body'));

--- a/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/intent_analyzer_experimental_test.dart
@@ -99,6 +99,22 @@ void main() {
       );
     });
 
+    test('parses intent schema field', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @IntentSpec(
+          identifier: 'com.example.setRead',
+          title: 'Set Read',
+          schema: 'messages.setMessageReadStatus',
+        )
+        class SetReadIntent extends IntentSpecBase {}
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'SetReadIntent'));
+      expect(result!.schema, equals('messages.setMessageReadStatus'));
+    });
+
     test('rejects cancellable combined with foreground mode', () async {
       final library = await resolveSource('''
         import 'package:app_intents_annotations/app_intents_annotations.dart';

--- a/packages/app_intents_codegen/test/generator/swift_generator_property_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_property_test.dart
@@ -1,0 +1,121 @@
+import 'package:app_intents_codegen/src/generator/swift_generator.dart';
+import 'package:app_intents_codegen/src/models/entity_info.dart';
+import 'package:test/test.dart';
+
+EntityInfo _entityWith(EntityPropertyInfo extra) => EntityInfo(
+  className: 'NoteEntity',
+  identifier: 'com.example.note',
+  title: 'Note',
+  pluralTitle: 'Notes',
+  properties: [
+    const EntityPropertyInfo(
+      fieldName: 'id',
+      dartType: 'String',
+      role: EntityPropertyRole.id,
+    ),
+    const EntityPropertyInfo(
+      fieldName: 'title',
+      dartType: 'String',
+      role: EntityPropertyRole.title,
+    ),
+    extra,
+  ],
+);
+
+void main() {
+  // @Property semantic indexing is a normal feature (no experimental flag).
+  group('SwiftGenerator (@Property semantic indexing #50)', () {
+    test('indexingKey emits @Property(indexingKey:) at iOS 18.4', () {
+      final result = const SwiftGenerator().generateEntity(
+        _entityWith(
+          const EntityPropertyInfo(
+            fieldName: 'body',
+            dartType: 'String',
+            role: EntityPropertyRole.none,
+            exposeAsProperty: true,
+            indexingKey: 'contentDescription',
+          ),
+        ),
+      );
+
+      expect(result, contains('import CoreSpotlight'));
+      expect(result, contains('@available(iOS 18.4, *)'));
+      expect(
+        result,
+        contains(r'@Property(indexingKey: \.contentDescription)'),
+      );
+      expect(result, contains('var body: String'));
+      // Not gated by the experimental flag.
+      expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+    });
+
+    test('exposed property gets a custom init with a default value', () {
+      final result = const SwiftGenerator().generateEntity(
+        _entityWith(
+          const EntityPropertyInfo(
+            fieldName: 'body',
+            dartType: 'String',
+            role: EntityPropertyRole.none,
+            exposeAsProperty: true,
+            indexingKey: 'contentDescription',
+          ),
+        ),
+      );
+
+      expect(
+        result,
+        contains('init(id: String, title: String, body: String = "")'),
+      );
+      expect(result, contains('self.body = body'));
+      // The query constructs the entity and populates the property from the dict.
+      expect(result, contains('let body = dict["body"] as? String'));
+      expect(
+        result,
+        contains('NoteEntity(id: id, title: title, body: body ?? "")'),
+      );
+    });
+
+    test('title-only @Property stays at iOS 17 (no indexingKey)', () {
+      final result = const SwiftGenerator().generateEntity(
+        _entityWith(
+          const EntityPropertyInfo(
+            fieldName: 'body',
+            dartType: 'String',
+            role: EntityPropertyRole.none,
+            exposeAsProperty: true,
+            propertyTitle: 'Body',
+          ),
+        ),
+      );
+
+      expect(result, contains('@Property(title: "Body")'));
+      expect(result, contains('@available(iOS 17.0, *)'));
+      expect(result, isNot(contains('import CoreSpotlight')));
+    });
+
+    test('entities without exposed properties are unchanged (no init)', () {
+      final result = const SwiftGenerator().generateEntity(
+        EntityInfo(
+          className: 'NoteEntity',
+          identifier: 'com.example.note',
+          title: 'Note',
+          pluralTitle: 'Notes',
+          properties: const [
+            EntityPropertyInfo(
+              fieldName: 'id',
+              dartType: 'String',
+              role: EntityPropertyRole.id,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'title',
+              dartType: 'String',
+              role: EntityPropertyRole.title,
+            ),
+          ],
+        ),
+      );
+      expect(result, isNot(contains('init(')));
+      expect(result, isNot(contains('@Property')));
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/generator/swift_generator_property_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_property_test.dart
@@ -1,5 +1,6 @@
 import 'package:app_intents_codegen/src/generator/swift_generator.dart';
 import 'package:app_intents_codegen/src/models/entity_info.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 EntityInfo _entityWith(EntityPropertyInfo extra) => EntityInfo(
@@ -40,10 +41,7 @@ void main() {
 
       expect(result, contains('import CoreSpotlight'));
       expect(result, contains('@available(iOS 18.4, *)'));
-      expect(
-        result,
-        contains(r'@Property(indexingKey: \.contentDescription)'),
-      );
+      expect(result, contains(r'@Property(indexingKey: \.contentDescription)'));
       expect(result, contains('var body: String'));
       // Not gated by the experimental flag.
       expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
@@ -91,6 +89,99 @@ void main() {
       expect(result, contains('@Property(title: "Body")'));
       expect(result, contains('@available(iOS 17.0, *)'));
       expect(result, isNot(contains('import CoreSpotlight')));
+    });
+
+    test('init param order follows role order, not Dart field order, so it '
+        'matches the construction call site', () {
+      // The exposed `body` property is declared BEFORE the `icon` image role
+      // field. The generated init must still list role fields first
+      // (id, title, icon) then `body`, matching the call site — emitting in
+      // field order would produce `init(..., body:, icon:)` while the call
+      // passes `(..., icon:, body:)`, which does not compile in Swift.
+      final result = const SwiftGenerator().generateEntity(
+        EntityInfo(
+          className: 'NoteEntity',
+          identifier: 'com.example.note',
+          title: 'Note',
+          pluralTitle: 'Notes',
+          properties: const [
+            EntityPropertyInfo(
+              fieldName: 'id',
+              dartType: 'String',
+              role: EntityPropertyRole.id,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'title',
+              dartType: 'String',
+              role: EntityPropertyRole.title,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'body',
+              dartType: 'String',
+              role: EntityPropertyRole.none,
+              exposeAsProperty: true,
+              indexingKey: 'contentDescription',
+            ),
+            EntityPropertyInfo(
+              fieldName: 'icon',
+              dartType: 'String',
+              role: EntityPropertyRole.image,
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        result,
+        contains(
+          'init(id: String, title: String, icon: String, body: String = "")',
+        ),
+      );
+      expect(
+        result,
+        contains('NoteEntity(id: id, title: title, icon: icon, body: '),
+      );
+      // The broken field-order signature must NOT appear.
+      expect(
+        result,
+        isNot(contains('init(id: String, title: String, body: String')),
+      );
+    });
+
+    test('non-String exposed property uses a type-correct default '
+        '(DateTime -> Date())', () {
+      final result = const SwiftGenerator().generateEntity(
+        _entityWith(
+          const EntityPropertyInfo(
+            fieldName: 'createdAt',
+            dartType: 'DateTime',
+            role: EntityPropertyRole.none,
+            exposeAsProperty: true,
+            propertyTitle: 'Created',
+          ),
+        ),
+      );
+
+      expect(result, contains('createdAt: Date = Date()'));
+      // The bogus empty-string default for a non-String type must be gone.
+      expect(result, isNot(contains('createdAt: Date = ""')));
+    });
+
+    test('exposing an unsupported property type is rejected', () {
+      expect(
+        () => const SwiftGenerator().generateEntity(
+          _entityWith(
+            const EntityPropertyInfo(
+              fieldName: 'payload',
+              dartType: 'CustomType',
+              role: EntityPropertyRole.none,
+              exposeAsProperty: true,
+              propertyTitle: 'Payload',
+            ),
+          ),
+        ),
+        throwsA(isA<InvalidGenerationSourceError>()),
+      );
     });
 
     test('entities without exposed properties are unchanged (no init)', () {

--- a/packages/app_intents_codegen/test/generator/swift_generator_schema_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_schema_test.dart
@@ -1,0 +1,113 @@
+import 'package:app_intents_codegen/src/experimental/experimental_features.dart';
+import 'package:app_intents_codegen/src/generator/swift_generator.dart';
+import 'package:app_intents_codegen/src/models/entity_info.dart';
+import 'package:app_intents_codegen/src/models/intent_info.dart';
+import 'package:test/test.dart';
+
+SwiftGenerator _schemaGenerator() => const SwiftGenerator(
+  experimental: ExperimentalFeatures(
+    masterEnabled: true,
+    enabled: {ExperimentalFeature.appSchema},
+  ),
+);
+
+EntityInfo _entity({String? schema, bool indexed = false}) => EntityInfo(
+  className: 'MessageEntity',
+  identifier: 'com.example.message',
+  title: 'Message',
+  pluralTitle: 'Messages',
+  schema: schema,
+  indexed: indexed,
+  properties: const [
+    EntityPropertyInfo(
+      fieldName: 'id',
+      dartType: 'String',
+      role: EntityPropertyRole.id,
+    ),
+    EntityPropertyInfo(
+      fieldName: 'title',
+      dartType: 'String',
+      role: EntityPropertyRole.title,
+    ),
+  ],
+);
+
+void main() {
+  group('SwiftGenerator (WWDC26 App Schema #49)', () {
+    group('entity schema', () {
+      test('emits @AppEntity(schema:) dual-branch when enabled', () {
+        final result = _schemaGenerator().generateAll(
+          entities: [_entity(schema: 'messages.message')],
+        );
+
+        expect(result, contains('#if APP_INTENTS_WWDC26'));
+        expect(result, contains('@available(iOS 27.0, *)'));
+        expect(result, contains('@AppEntity(schema: .messages.message)'));
+        expect(result, contains('#else'));
+        expect(result, contains('#endif'));
+
+        // The query struct also moves to iOS 27 inside the experimental branch.
+        final ifIndex = result.indexOf('#if APP_INTENTS_WWDC26');
+        final elseIndex = result.indexOf('#else');
+        final ifBranch = result.substring(ifIndex, elseIndex);
+        expect(ifBranch, contains('struct MessageEntityQuery: EntityQuery'));
+        expect(ifBranch, contains('@available(iOS 27.0, *)'));
+
+        // The #else branch is the stable form: no macro, iOS 17.
+        final endifIndex = result.indexOf('#endif');
+        final elseBranch = result.substring(elseIndex, endifIndex);
+        expect(elseBranch, contains('@available(iOS 17.0, *)'));
+        expect(elseBranch, isNot(contains('@AppEntity(schema:')));
+      });
+
+      test('default generator emits no schema macro', () {
+        final result = const SwiftGenerator().generateAll(
+          entities: [_entity(schema: 'messages.message')],
+        );
+        expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+        expect(result, isNot(contains('@AppEntity(schema:')));
+        expect(result, contains('struct MessageEntity: AppEntity {'));
+      });
+
+      test('schema + indexed moves the IndexedEntity extension to iOS 27', () {
+        final result = _schemaGenerator().generateAll(
+          entities: [_entity(schema: 'messages.message', indexed: true)],
+        );
+        final ifIndex = result.indexOf('#if APP_INTENTS_WWDC26');
+        final elseIndex = result.indexOf('#else');
+        final ifBranch = result.substring(ifIndex, elseIndex);
+        expect(ifBranch, contains('extension MessageEntity: IndexedEntity'));
+        // No iOS 26 gate inside the experimental branch — everything is iOS 27.
+        expect(ifBranch, isNot(contains('@available(iOS 26.0, *)')));
+      });
+    });
+
+    group('intent schema', () {
+      test('emits @AppIntent(schema:) dual-branch when enabled', () {
+        final result = _schemaGenerator().generateAll(
+          intents: [
+            const IntentInfo(
+              className: 'SetReadIntent',
+              identifier: 'com.example.setRead',
+              title: 'Set Read',
+              implementation: IntentImplementationType.dart,
+              schema: 'messages.setMessageReadStatus',
+              parameters: [],
+            ),
+          ],
+        );
+
+        expect(result, contains('#if APP_INTENTS_WWDC26'));
+        expect(
+          result,
+          contains('@AppIntent(schema: .messages.setMessageReadStatus)'),
+        );
+        expect(result, contains('@available(iOS 27.0, *)'));
+        expect(result, contains('#else'));
+        // Stable fallback has no macro.
+        final elseBranch = result.substring(result.indexOf('#else'));
+        expect(elseBranch, isNot(contains('@AppIntent(schema:')));
+      });
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/test_utils.dart
+++ b/packages/app_intents_codegen/test/test_utils.dart
@@ -47,6 +47,7 @@ Future<LibraryElement> resolveSource(String source) async {
           final bool longRunning;
           final bool cancellable;
           final List<IntentExecutionTarget>? executionTargets;
+          final String? schema;
 
           const IntentSpec({
             required this.identifier,
@@ -61,6 +62,7 @@ Future<LibraryElement> resolveSource(String source) async {
             this.longRunning = false,
             this.cancellable = false,
             this.executionTargets,
+            this.schema,
           });
         }
 
@@ -107,6 +109,7 @@ Future<LibraryElement> resolveSource(String source) async {
           final bool indexed;
           final bool enumerable;
           final String? persistedCacheKey;
+          final String? schema;
 
           const EntitySpec({
             required this.identifier,
@@ -117,6 +120,7 @@ Future<LibraryElement> resolveSource(String source) async {
             this.indexed = false,
             this.enumerable = false,
             this.persistedCacheKey,
+            this.schema,
           });
         }
       ''',
@@ -139,6 +143,12 @@ Future<LibraryElement> resolveSource(String source) async {
 
         class EntityDefaultQuery {
           const EntityDefaultQuery();
+        }
+
+        class EntityProperty {
+          final String? title;
+          final String? indexingKey;
+          const EntityProperty({this.title, this.indexingKey});
         }
       ''',
       'app_intents_annotations|lib/src/bases/intent_spec_base.dart': '''


### PR DESCRIPTION
> **Stacked on #60** (base branch = `worktree-wwdc26-experimental-codegen`). Review/merge #60 first.

## 概要

WWDC26 opt-in 機構（#52 / PR #60）の上に、entity/intent の2機能を追加。すべて Xcode 27 beta SDK で **dual-branch コンパイル検証済み**。

## #49 App Schema（experimental・iOS 27）

- `@EntitySpec(schema:)` / `@IntentSpec(schema:)` に `'messages.message'` のような `domain.schema` 文字列を指定。
- `app-schema` 機能フラグON時に dual-branch 生成: `#if APP_INTENTS_WWDC26` で `@AppEntity(schema:)` / `@AppIntent(schema:)` マクロ（entity struct・query・extensions をまとめて iOS 27 へ）、`#else` で安定版。
- **SDK実測でマクロが寛容**と判明（既存生成 entity にマクロ前置だけで通る／スキーマ固有プロパティは optional・synthesized／明示 `: AppEntity` も冗長OK）→ 薄い追加変更で実現。

## #50 @Property セマンティックインデックス（通常機能・iOS 18.4）

- `@EntityProperty(title:, indexingKey:)` で entity フィールドを Swift `@Property(...)` 出力。`indexingKey: 'contentDescription'` → `@Property(indexingKey: \.contentDescription)`（Spotlight/Apple Intelligence 向け）。
- `indexingKey` init は **iOS 18.4（安定SDK）** なので experimental フラグではなく `@available(iOS 18.4, *)` の通常機能。
- `@Property`/`EntityProperty` ラッパーに **`init(wrappedValue:)` が無い** ため、プロパティ公開 entity には明示 initializer を生成（公開プロパティはデフォルト値付き）。これで生成 query の role-only 構築がそのままコンパイル可、文字列プロパティは bridge dict から populate。

## 検証

- codegen **286** + annotations **8** テスト緑（回帰ゼロ、既存出力不変）
- `dart analyze` クリーン
- **dual-branch `swiftc -typecheck` 緑**（schema × indexed × enumerable × `@Property` の組合せ。安定分岐 @ iOS 18.4 / experimental分岐 @ iOS 27）

## スコープ外（フォローアップ）

- `IndexedEntityQuery` 再インデックス（iOS 27）、ドネーション系ランタイムAPI、`@AppEnum(schema:)`、`@ComputedProperty`（iOS 26）は別PR。

Refs #59, #49, #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #50

Also part of #49 (App Schema) — entity/intent schema here; the enum-schema half lands in #62, which closes #49.

> Review note: an out-of-order entity-init bug in the default `@Property` path was found in review and fixed in this PR (init params now follow the call-site role order; unsupported exposed types are rejected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@EntityProperty` annotation for exposing entity fields as Swift properties with optional titles and semantic indexing keys.
  * Introduced experimental App Schema support for entities and intents via optional `schema` field in `@EntitySpec` and `@IntentSpec`.
  * Enabled semantic indexing for entity properties (iOS 18.4+) with automatic availability gating.
  * Enhanced entity initialization to support exposed string properties from cached data.

* **Documentation**
  * Updated CLAUDE.md with detailed App Schema and semantic indexing feature specifications, including macro behavior and SDK-verified API facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->