### PR TITLE
feat(codegen): enum App Schema (#49) + entity ownership (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,11 @@ docs/
   - `@EntitySpec(schema:)` / `@IntentSpec(schema:)` (e.g. `'messages.message'`) → dual-branch `@AppEntity(schema: .messages.message)` / `@AppIntent(schema: .messages.setMessageReadStatus)` gated by the `app-schema` experimental feature (iOS 27). The entity struct, its query and extensions all move to iOS 27 in the `#if` branch.
   - `@EntityProperty(title:, indexingKey:)` → Swift `@Property(...)`; `indexingKey: 'contentDescription'` emits `@Property(indexingKey: \.contentDescription)` for semantic indexing. **Normal feature (no experimental flag)** gated at `@available(iOS 18.4, *)`.
   - Entities that expose `@Property` get an explicit initializer (the `@Property`/`EntityProperty` wrapper has **no `init(wrappedValue:)`**), with defaults so the role-only construction in the generated query keeps compiling.
-  - Verified: 286 codegen + 8 annotation tests green; dual-branch `swiftc -typecheck` green for schema × indexed × enumerable × `@Property` combinations (stable @ iOS 18.4, experimental @ iOS 27).
+  - Verified: dual-branch `swiftc -typecheck` green for schema × indexed × enumerable × `@Property` combinations (stable @ iOS 18.4, experimental @ iOS 27).
+- **WWDC26 enum schema (#49) + entity ownership (#55)**
+  - `@EnumSpec(schema:)` → dual-branch `@AppEnum(schema: .messages.messageType)` (gated by the `app-schema` feature, iOS 27). The `@AppEnum(schema:)` macro is lenient like the entity/intent variants.
+  - `@EntitySpec(ownership:)` (`EntityOwnershipState.unknown/.shared/.public`) → an additive `OwnershipProvidingEntity` conformance extension (`var ownership: EntityOwnership { .shared }`) in its own `#if APP_INTENTS_WWDC26` block (no `#else` — without the flag the entity simply isn't ownership-aware). Gated by the new `ownership` experimental feature (iOS 27).
+  - Verified: 296 codegen + 8 annotation tests green; dual-branch `swiftc -typecheck` green (stable @ iOS 17, experimental @ iOS 27).
 - `app_intents_annotations`: All annotations defined
   - `@IntentSpec` (with `urlScheme`/`urlAction`, `resultDialogTemplate`, `parameterSummary`)
   - `@IntentParam` (with `entityType` for entity picker, `enumType` for AppEnum parameters)

--- a/packages/app_intents_annotations/lib/app_intents_annotations.dart
+++ b/packages/app_intents_annotations/lib/app_intents_annotations.dart
@@ -2,6 +2,7 @@
 library;
 
 export 'src/annotations/app_shortcut.dart';
+export 'src/annotations/entity_ownership.dart';
 export 'src/annotations/entity_params.dart';
 export 'src/annotations/entity_spec.dart';
 export 'src/annotations/enum_spec.dart';

--- a/packages/app_intents_annotations/lib/src/annotations/entity_ownership.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/entity_ownership.dart
@@ -1,0 +1,19 @@
+/// The ownership state of an entity.
+///
+/// Maps to the WWDC26 `EntityOwnership` option set (iOS 27+). Declaring an
+/// entity's ownership lets Siri/Apple Intelligence decide whether an intent
+/// with side effects needs explicit confirmation.
+///
+/// This is an **experimental WWDC26 feature**: the generated
+/// `OwnershipProvidingEntity` conformance is only emitted when experimental
+/// code generation is enabled, wrapped in `#if APP_INTENTS_WWDC26`.
+enum EntityOwnershipState {
+  /// Ownership is unknown. Generates `.unknown`.
+  unknown,
+
+  /// The entity is shared with others. Generates `.shared`.
+  shared,
+
+  /// The entity is public. Generates `.public`.
+  public,
+}

--- a/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/entity_spec.dart
@@ -1,3 +1,5 @@
+import 'entity_ownership.dart';
+
 /// Annotation to specify an entity with its metadata.
 class EntitySpec {
   /// A unique identifier for the entity.
@@ -73,6 +75,15 @@ class EntitySpec {
   /// Has no effect unless experimental generation is enabled.
   final String? schema;
 
+  /// **Experimental (WWDC26, iOS 27+).** The ownership state of this entity.
+  ///
+  /// When experimental code generation is enabled (the `ownership` feature),
+  /// the generated Swift adds an `OwnershipProvidingEntity` conformance
+  /// declaring `var ownership: EntityOwnership`. Emitted in a
+  /// `#if APP_INTENTS_WWDC26` block. Has no effect unless experimental
+  /// generation is enabled.
+  final EntityOwnershipState? ownership;
+
   const EntitySpec({
     required this.identifier,
     required this.title,
@@ -83,5 +94,6 @@ class EntitySpec {
     this.enumerable = false,
     this.persistedCacheKey,
     this.schema,
+    this.ownership,
   });
 }

--- a/packages/app_intents_annotations/lib/src/annotations/enum_spec.dart
+++ b/packages/app_intents_annotations/lib/src/annotations/enum_spec.dart
@@ -20,7 +20,16 @@ class EnumSpec {
   /// A human-readable title for the enum type.
   final String title;
 
-  const EnumSpec({required this.identifier, required this.title});
+  /// **Experimental (WWDC26, iOS 27+).** The App Schema this enum conforms to,
+  /// as a dotted `domain.schema` path (e.g. `'messages.messageType'`).
+  ///
+  /// When experimental code generation is enabled (the `app-schema` feature),
+  /// the generated Swift adds the `@AppEnum(schema: .messages.messageType)`
+  /// macro, in a `#if APP_INTENTS_WWDC26` block with a stable fallback. Has no
+  /// effect unless experimental generation is enabled.
+  final String? schema;
+
+  const EnumSpec({required this.identifier, required this.title, this.schema});
 }
 
 /// Annotation to customize the display title of an enum case.

--- a/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/entity_analyzer.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: deprecated_member_use, unnecessary_non_null_assertion
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -77,6 +78,7 @@ class EntityAnalyzer {
         .getField('persistedCacheKey')
         ?.toStringValue();
     final schema = annotation.getField('schema')?.toStringValue();
+    final ownership = _parseOwnership(annotation.getField('ownership'));
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -113,7 +115,25 @@ class EntityAnalyzer {
       enumerable: enumerable,
       persistedCacheKey: persistedCacheKey,
       schema: schema,
+      ownership: ownership,
     );
+  }
+
+  /// Parses the `ownership` enum value (`EntityOwnershipState`) into the model
+  /// type, or `null` when absent.
+  EntityOwnershipType? _parseOwnership(DartObject? field) {
+    if (field == null || field.isNull) return null;
+    final index = field.getField('index')?.toIntValue();
+    switch (index) {
+      case 0:
+        return EntityOwnershipType.unknown;
+      case 1:
+        return EntityOwnershipType.shared;
+      case 2:
+        return EntityOwnershipType.public;
+      default:
+        return null;
+    }
   }
 
   String? _extractModelType(ClassElement element) {

--- a/packages/app_intents_codegen/lib/src/analyzer/enum_analyzer.dart
+++ b/packages/app_intents_codegen/lib/src/analyzer/enum_analyzer.dart
@@ -33,6 +33,7 @@ class EnumAnalyzer {
 
     final identifier = annotation.getField('identifier')?.toStringValue();
     final title = annotation.getField('title')?.toStringValue();
+    final schema = annotation.getField('schema')?.toStringValue();
 
     if (identifier == null) {
       throw InvalidGenerationSourceError(
@@ -54,6 +55,7 @@ class EnumAnalyzer {
       identifier: identifier,
       title: title,
       cases: cases,
+      schema: schema,
     );
   }
 

--- a/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
+++ b/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
@@ -16,7 +16,10 @@ enum ExperimentalFeature {
   longRunning('long-running'),
 
   /// App Schema domain conformance (#49): `@AppEntity(schema:)` and friends.
-  appSchema('app-schema');
+  appSchema('app-schema'),
+
+  /// Entity ownership (#55): `OwnershipProvidingEntity` conformance.
+  ownership('ownership');
 
   const ExperimentalFeature(this.flag);
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -621,6 +621,39 @@ class SwiftGenerator {
         indexedAvailability: 'iOS 26.0',
       );
     }
+
+    // #55 ownership: a purely additive iOS 27 conformance, in its own #if block
+    // (no #else needed — without the flag the entity just isn't ownership-aware).
+    if (experimental.isEnabled(ExperimentalFeature.ownership) &&
+        info.ownership != null) {
+      buffer.writeln();
+      buffer.writeln();
+      _writeOwnershipExtension(buffer, info);
+    }
+  }
+
+  /// Writes the experimental `OwnershipProvidingEntity` conformance extension.
+  void _writeOwnershipExtension(StringBuffer buffer, EntityInfo info) {
+    buffer.writeln('#if APP_INTENTS_WWDC26');
+    buffer.writeln('@available(iOS 27.0, *)');
+    buffer.writeln('extension ${info.className}: OwnershipProvidingEntity {');
+    buffer.writeln(
+      '${_indent}var ownership: EntityOwnership { ${_ownershipToSwift(info.ownership!)} }',
+    );
+    buffer.writeln('}');
+    buffer.write('#endif');
+  }
+
+  /// Maps an ownership state to its Swift `EntityOwnership` member.
+  String _ownershipToSwift(EntityOwnershipType ownership) {
+    switch (ownership) {
+      case EntityOwnershipType.unknown:
+        return '.unknown';
+      case EntityOwnershipType.shared:
+        return '.shared';
+      case EntityOwnershipType.public:
+        return '.public';
+    }
   }
 
   /// Whether [info] should emit the `@AppEntity(schema:)` macro.
@@ -1465,8 +1498,42 @@ class SwiftGenerator {
   }
 
   /// Generates enum body without import statement.
+  ///
+  /// When the `app-schema` experimental feature is enabled and a schema is set,
+  /// emits the `@AppEnum(schema:)` form in `#if APP_INTENTS_WWDC26` and the
+  /// stable form in `#else`.
   void _generateEnumBody(StringBuffer buffer, EnumInfo info) {
-    buffer.writeln('@available(iOS 17.0, *)');
+    if (experimental.isEnabled(ExperimentalFeature.appSchema) &&
+        info.schema != null) {
+      buffer.writeln('#if APP_INTENTS_WWDC26');
+      _writeEnumStruct(
+        buffer,
+        info,
+        availability: 'iOS 27.0',
+        schemaMacro: '@AppEnum(schema: .${info.schema})',
+      );
+      buffer.writeln();
+      buffer.writeln('#else');
+      _writeEnumStruct(buffer, info, availability: 'iOS 17.0');
+      buffer.writeln();
+      buffer.write('#endif');
+    } else {
+      _writeEnumStruct(buffer, info, availability: 'iOS 17.0');
+    }
+  }
+
+  /// Writes the enum declaration at the given availability, optionally prefixed
+  /// with an App Schema macro.
+  void _writeEnumStruct(
+    StringBuffer buffer,
+    EnumInfo info, {
+    required String availability,
+    String? schemaMacro,
+  }) {
+    buffer.writeln('@available($availability, *)');
+    if (schemaMacro != null) {
+      buffer.writeln(schemaMacro);
+    }
     buffer.writeln('enum ${info.className}: String, AppEnum {');
 
     // Cases

--- a/packages/app_intents_codegen/lib/src/models/entity_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/entity_info.dart
@@ -44,6 +44,11 @@ class EntityInfo {
   /// `@AppEntity(schema:)` macro (dual-branch).
   final String? schema;
 
+  /// Experimental (WWDC26 #55): the entity's ownership state. When set and the
+  /// `ownership` feature is enabled, adds an `OwnershipProvidingEntity`
+  /// conformance.
+  final EntityOwnershipType? ownership;
+
   const EntityInfo({
     required this.className,
     required this.identifier,
@@ -57,6 +62,7 @@ class EntityInfo {
     this.enumerable = false,
     this.persistedCacheKey,
     this.schema,
+    this.ownership,
   });
 
   /// Whether any property is exposed as a Swift `@Property`. Such entities need
@@ -95,6 +101,7 @@ class EntityInfo {
         enumerable == other.enumerable &&
         persistedCacheKey == other.persistedCacheKey &&
         schema == other.schema &&
+        ownership == other.ownership &&
         _listEquals(properties, other.properties);
   }
 
@@ -111,6 +118,7 @@ class EntityInfo {
     enumerable,
     persistedCacheKey,
     schema,
+    ownership,
     Object.hashAll(properties),
   );
 
@@ -119,7 +127,8 @@ class EntityInfo {
       'EntityInfo(className: $className, identifier: $identifier, title: $title, '
       'pluralTitle: $pluralTitle, description: $description, modelType: $modelType, '
       'displayImageName: $displayImageName, indexed: $indexed, enumerable: $enumerable, '
-      'persistedCacheKey: $persistedCacheKey, schema: $schema, properties: $properties)';
+      'persistedCacheKey: $persistedCacheKey, schema: $schema, ownership: $ownership, '
+      'properties: $properties)';
 }
 
 /// Represents analyzed information about an entity property.
@@ -181,6 +190,10 @@ class EntityPropertyInfo {
       'exposeAsProperty: $exposeAsProperty, propertyTitle: $propertyTitle, '
       'indexingKey: $indexingKey)';
 }
+
+/// Experimental (WWDC26 #55): the ownership state of an entity, mapped to a
+/// member of the Swift `EntityOwnership` option set.
+enum EntityOwnershipType { unknown, shared, public }
 
 /// The role of an entity property.
 enum EntityPropertyRole {

--- a/packages/app_intents_codegen/lib/src/models/enum_info.dart
+++ b/packages/app_intents_codegen/lib/src/models/enum_info.dart
@@ -12,11 +12,17 @@ class EnumInfo {
   /// The enum cases with their display metadata.
   final List<EnumCaseInfo> cases;
 
+  /// Experimental (WWDC26): the App Schema this enum conforms to, as a dotted
+  /// `domain.schema` path (e.g. `messages.messageType`). When set and the
+  /// `app-schema` feature is enabled, adds the `@AppEnum(schema:)` macro.
+  final String? schema;
+
   const EnumInfo({
     required this.className,
     required this.identifier,
     required this.title,
     required this.cases,
+    this.schema,
   });
 
   @override
@@ -26,17 +32,18 @@ class EnumInfo {
     return className == other.className &&
         identifier == other.identifier &&
         title == other.title &&
+        schema == other.schema &&
         _listEquals(cases, other.cases);
   }
 
   @override
   int get hashCode =>
-      Object.hash(className, identifier, title, Object.hashAll(cases));
+      Object.hash(className, identifier, title, schema, Object.hashAll(cases));
 
   @override
   String toString() =>
       'EnumInfo(className: $className, identifier: $identifier, '
-      'title: $title, cases: $cases)';
+      'title: $title, schema: $schema, cases: $cases)';
 }
 
 /// Represents a single case of an AppEnum.

--- a/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/entity_analyzer_schema_test.dart
@@ -1,4 +1,5 @@
 import 'package:app_intents_codegen/src/analyzer/entity_analyzer.dart';
+import 'package:app_intents_codegen/src/models/entity_info.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -52,6 +53,28 @@ void main() {
 
       final result = analyzer.analyze(findClass(library, 'MessageEntity'));
       expect(result!.schema, isNull);
+    });
+
+    test('parses ownership field', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EntitySpec(
+          identifier: 'com.example.thing',
+          title: 'Thing',
+          pluralTitle: 'Things',
+          ownership: EntityOwnershipState.shared,
+        )
+        class ThingEntity extends EntitySpecBase {
+          @EntityId()
+          final String id = '';
+          @EntityTitle()
+          final String title = '';
+        }
+      ''');
+
+      final result = analyzer.analyze(findClass(library, 'ThingEntity'));
+      expect(result!.ownership, equals(EntityOwnershipType.shared));
     });
 
     test('parses @EntityProperty with title and indexingKey', () async {

--- a/packages/app_intents_codegen/test/analyzer/enum_analyzer_schema_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/enum_analyzer_schema_test.dart
@@ -1,0 +1,51 @@
+import 'package:app_intents_codegen/src/analyzer/enum_analyzer.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('EnumAnalyzer (WWDC26 #49 schema)', () {
+    late EnumAnalyzer analyzer;
+
+    setUp(() {
+      analyzer = EnumAnalyzer();
+    });
+
+    test('parses enum schema field', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EnumSpec(
+          identifier: 'com.example.MessageType',
+          title: 'Message Type',
+          schema: 'messages.messageType',
+        )
+        enum MessageType {
+          text,
+          image,
+        }
+      ''');
+
+      final result = analyzer.analyze(findEnum(library, 'MessageType'));
+      expect(result!.schema, equals('messages.messageType'));
+      expect(result.cases.map((c) => c.name), containsAll(['text', 'image']));
+    });
+
+    test('schema defaults to null', () async {
+      final library = await resolveSource('''
+        import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+        @EnumSpec(
+          identifier: 'com.example.MessageType',
+          title: 'Message Type',
+        )
+        enum MessageType {
+          text,
+        }
+      ''');
+
+      final result = analyzer.analyze(findEnum(library, 'MessageType'));
+      expect(result!.schema, isNull);
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/generator/swift_generator_enum_ownership_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_enum_ownership_test.dart
@@ -4,32 +4,31 @@ import 'package:app_intents_codegen/src/models/entity_info.dart';
 import 'package:app_intents_codegen/src/models/enum_info.dart';
 import 'package:test/test.dart';
 
-SwiftGenerator _allExperimental() =>
-    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
-
-EntityInfo _entity({
-  String? schema,
-  EntityOwnershipType? ownership,
-}) => EntityInfo(
-  className: 'ThingEntity',
-  identifier: 'com.example.thing',
-  title: 'Thing',
-  pluralTitle: 'Things',
-  schema: schema,
-  ownership: ownership,
-  properties: const [
-    EntityPropertyInfo(
-      fieldName: 'id',
-      dartType: 'String',
-      role: EntityPropertyRole.id,
-    ),
-    EntityPropertyInfo(
-      fieldName: 'title',
-      dartType: 'String',
-      role: EntityPropertyRole.title,
-    ),
-  ],
+SwiftGenerator _allExperimental() => const SwiftGenerator(
+  experimental: ExperimentalFeatures(masterEnabled: true),
 );
+
+EntityInfo _entity({String? schema, EntityOwnershipType? ownership}) =>
+    EntityInfo(
+      className: 'ThingEntity',
+      identifier: 'com.example.thing',
+      title: 'Thing',
+      pluralTitle: 'Things',
+      schema: schema,
+      ownership: ownership,
+      properties: const [
+        EntityPropertyInfo(
+          fieldName: 'id',
+          dartType: 'String',
+          role: EntityPropertyRole.id,
+        ),
+        EntityPropertyInfo(
+          fieldName: 'title',
+          dartType: 'String',
+          role: EntityPropertyRole.title,
+        ),
+      ],
+    );
 
 void main() {
   group('SwiftGenerator (#49 enum schema)', () {

--- a/packages/app_intents_codegen/test/generator/swift_generator_enum_ownership_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_enum_ownership_test.dart
@@ -1,0 +1,102 @@
+import 'package:app_intents_codegen/src/experimental/experimental_features.dart';
+import 'package:app_intents_codegen/src/generator/swift_generator.dart';
+import 'package:app_intents_codegen/src/models/entity_info.dart';
+import 'package:app_intents_codegen/src/models/enum_info.dart';
+import 'package:test/test.dart';
+
+SwiftGenerator _allExperimental() =>
+    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
+
+EntityInfo _entity({
+  String? schema,
+  EntityOwnershipType? ownership,
+}) => EntityInfo(
+  className: 'ThingEntity',
+  identifier: 'com.example.thing',
+  title: 'Thing',
+  pluralTitle: 'Things',
+  schema: schema,
+  ownership: ownership,
+  properties: const [
+    EntityPropertyInfo(
+      fieldName: 'id',
+      dartType: 'String',
+      role: EntityPropertyRole.id,
+    ),
+    EntityPropertyInfo(
+      fieldName: 'title',
+      dartType: 'String',
+      role: EntityPropertyRole.title,
+    ),
+  ],
+);
+
+void main() {
+  group('SwiftGenerator (#49 enum schema)', () {
+    EnumInfo enumInfo({String? schema}) => EnumInfo(
+      className: 'MessageType',
+      identifier: 'com.example.MessageType',
+      title: 'Message Type',
+      schema: schema,
+      cases: const [
+        EnumCaseInfo(name: 'text', displayTitle: 'Text'),
+        EnumCaseInfo(name: 'image', displayTitle: 'Image'),
+      ],
+    );
+
+    test('emits @AppEnum(schema:) dual-branch when enabled', () {
+      final result = _allExperimental().generateAll(
+        enums: [enumInfo(schema: 'messages.messageType')],
+      );
+      expect(result, contains('#if APP_INTENTS_WWDC26'));
+      expect(result, contains('@AppEnum(schema: .messages.messageType)'));
+      expect(result, contains('@available(iOS 27.0, *)'));
+      expect(result, contains('#else'));
+      final elseBranch = result.substring(result.indexOf('#else'));
+      expect(elseBranch, isNot(contains('@AppEnum(schema:')));
+    });
+
+    test('default generator emits no schema macro', () {
+      final result = const SwiftGenerator().generateAll(
+        enums: [enumInfo(schema: 'messages.messageType')],
+      );
+      expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+      expect(result, isNot(contains('@AppEnum(schema:')));
+      expect(result, contains('enum MessageType: String, AppEnum {'));
+    });
+  });
+
+  group('SwiftGenerator (#55 ownership)', () {
+    test('emits OwnershipProvidingEntity extension in #if block', () {
+      final result = _allExperimental().generateAll(
+        entities: [_entity(ownership: EntityOwnershipType.shared)],
+      );
+      expect(result, contains('#if APP_INTENTS_WWDC26'));
+      expect(
+        result,
+        contains('extension ThingEntity: OwnershipProvidingEntity {'),
+      );
+      expect(result, contains('var ownership: EntityOwnership { .shared }'));
+      expect(result, contains('@available(iOS 27.0, *)'));
+    });
+
+    test('maps each ownership state', () {
+      final pub = _allExperimental().generateAll(
+        entities: [_entity(ownership: EntityOwnershipType.public)],
+      );
+      expect(pub, contains('var ownership: EntityOwnership { .public }'));
+
+      final unknown = _allExperimental().generateAll(
+        entities: [_entity(ownership: EntityOwnershipType.unknown)],
+      );
+      expect(unknown, contains('var ownership: EntityOwnership { .unknown }'));
+    });
+
+    test('default generator emits no ownership extension', () {
+      final result = const SwiftGenerator().generateAll(
+        entities: [_entity(ownership: EntityOwnershipType.shared)],
+      );
+      expect(result, isNot(contains('OwnershipProvidingEntity')));
+    });
+  });
+}

--- a/packages/app_intents_codegen/test/test_utils.dart
+++ b/packages/app_intents_codegen/test/test_utils.dart
@@ -110,6 +110,7 @@ Future<LibraryElement> resolveSource(String source) async {
           final bool enumerable;
           final String? persistedCacheKey;
           final String? schema;
+          final EntityOwnershipState? ownership;
 
           const EntitySpec({
             required this.identifier,
@@ -121,8 +122,11 @@ Future<LibraryElement> resolveSource(String source) async {
             this.enumerable = false,
             this.persistedCacheKey,
             this.schema,
+            this.ownership,
           });
         }
+
+        enum EntityOwnershipState { unknown, shared, public }
       ''',
       'app_intents_annotations|lib/src/annotations/entity_params.dart': '''
         class EntityId {
@@ -165,10 +169,12 @@ Future<LibraryElement> resolveSource(String source) async {
         class EnumSpec {
           final String identifier;
           final String title;
+          final String? schema;
 
           const EnumSpec({
             required this.identifier,
             required this.title,
+            this.schema,
           });
         }
 


### PR DESCRIPTION
> **Stacked on #61** (base = `wwdc26-app-schema-indexing`). Review/merge #60 → #61 → this in order.

## 概要

App Schema / semantic-indexing PR の上に、クリーンで追加的な WWDC26 codegen 2機能。両方 Xcode 27 beta SDK で dual-branch コンパイル検証済み。

## #49 enum schema（experimental・iOS 27）
- `@EnumSpec(schema:)` に `'messages.messageType'` 等を指定 → `app-schema` フラグON時に dual-branch `@AppEnum(schema:)`。マクロは entity/intent 版同様に寛容。

## #55 entity ownership（experimental・iOS 27）
- `@EntitySpec(ownership: EntityOwnershipState.shared/.public/.unknown)` → 新 `ownership` フラグで `OwnershipProvidingEntity` 準拠 extension（`var ownership: EntityOwnership { .shared }`）を**追加的に**出力。専用 `#if APP_INTENTS_WWDC26` ブロック（`#else` 不要 — フラグ無しなら ownership 非対応なだけ）。iOS27 extension を iOS17 entity に付けられる（Swift許容）。

## 検証
- codegen **296** + annotations **8** テスト緑（回帰ゼロ）
- `dart analyze` クリーン
- **dual-branch `swiftc -typecheck` 緑**（安定@17 / experimental@27、schema+ownership 併用含む）

Refs #59, #49, #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #49 (completes App Schema: enum schema here + entity/intent schema from #61).

Partially addresses #55 (entity ownership via `OwnershipProvidingEntity`). #55 also covers RelevantEntities / IntentDonationManager / SyncableEntity, which are out of scope here — leaving #55 open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity ownership configuration support now available with unknown, shared, and public states
  * Schema configuration support added for enum annotations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->