### PR TITLE
feat(codegen): Duration parameters via rich-types (#53 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,13 @@ docs/
 - **WWDC26 enum schema (#49) + entity ownership (#55)**
   - `@EnumSpec(schema:)` → dual-branch `@AppEnum(schema: .messages.messageType)` (gated by the `app-schema` feature, iOS 27). The `@AppEnum(schema:)` macro is lenient like the entity/intent variants.
   - `@EntitySpec(ownership:)` (`EntityOwnershipState.unknown/.shared/.public`) → an additive `OwnershipProvidingEntity` conformance extension (`var ownership: EntityOwnership { .shared }`) in its own `#if APP_INTENTS_WWDC26` block (no `#else` — without the flag the entity simply isn't ownership-aware). Gated by the new `ownership` experimental feature (iOS 27).
-  - Verified: 296 codegen + 8 annotation tests green; dual-branch `swiftc -typecheck` green (stable @ iOS 17, experimental @ iOS 27).
+  - Verified: dual-branch `swiftc -typecheck` green (stable @ iOS 17, experimental @ iOS 27).
+- **WWDC26 richer parameter types (#53, partial — `Duration` only)**
+  - A Dart `Duration` `@IntentParam` now generates a real duration parameter. **By default (and in the `#else` fallback)** it maps to `Measurement<UnitDuration>` (which the stable SDK supports, so it compiles everywhere and Shortcuts shows a duration picker). With the new `rich-types` experimental feature it upgrades to the **native iOS 27 `Duration`** type inside `#if APP_INTENTS_WWDC26` (dual-branch).
+  - Both branches pre-serialize to a normalized `<field>Micros: Int` local (native `Duration` via `.components.seconds`/`.attoseconds`; `Measurement` via `.converted(to: .seconds).value`), so the params dict / URL query / Dart side stay branch-agnostic. Dart deserializes with `Duration(microseconds:)`. Same `<field>Micros` pattern as IntentFile's `<field>FileInfo`.
+  - Triggers dual-branch only when `rich-types` is enabled **and** the intent has a `Duration` param; the native `Duration` type must never leak into the default/`#else` output (it has no `_IntentValue` conformance on the stable SDK → would not compile).
+  - Verified: dual-branch `swiftc -typecheck` green for a FlutterBridge `Duration` intent (fallback @ iOS 17, native @ iOS 27).
+  - **Deferred (need a Dart representation / handler-I/F design, not pure codegen)**: `PersonNameComponents` params (no equivalent Dart type), `@UnionValue`, `EntityCollection<T>`.
 - `app_intents_annotations`: All annotations defined
   - `@IntentSpec` (with `urlScheme`/`urlAction`, `resultDialogTemplate`, `parameterSummary`)
   - `@IntentParam` (with `entityType` for entity picker, `enumType` for AppEnum parameters)
@@ -241,6 +247,8 @@ MethodChannel only supports specific types. Non-supported types need conversion:
 | `DateTime?` | `Date?` | `.map { ISO8601DateFormatter().string(from: $0) }` |
 | `IntentFile` | `IntentFile` | Write data to temp file, serialize path/mimeType/filename to Map |
 | `IntentFile?` | `IntentFile?` | Same, wrapped in `if let` null check |
+| `Duration` | `Measurement<UnitDuration>` (default/`#else`) or native `Duration` (`#if`, `rich-types`) | Pre-serialize to `<field>Micros: Int` microseconds; Dart side `Duration(microseconds:)`. See WWDC26 #53. |
+| `Duration?` | `Measurement<UnitDuration>?` / `Duration?` | `<field>Micros: Int? = <field>.map { ... }` |
 
 SwiftGenerator automatically handles this conversion in generated code.
 
@@ -261,8 +269,9 @@ not emit those lines" is mandatory.
 
 **Flag mechanism** (`ExperimentalFeatures`):
 - `--experimental-wwdc26` master switch (OFF → nothing experimental is emitted).
-- `--experimental=<flag>` per-feature (`long-running`, `app-schema`). Master ON with
-  no per-feature flag = all features; with flags = only those.
+- `--experimental=<flag>` per-feature (`long-running`, `app-schema`, `ownership`,
+  `rich-types`). Master ON with no per-feature flag = all features; with flags = only
+  those.
 - Thread the flag through the **CLI + SwiftGenerator only** until a feature changes
   Dart output (then also wire `build.yaml`/`builder.dart`). #52 is Swift-only.
 
@@ -292,6 +301,7 @@ the `APP_INTENTS_WWDC26` build flag must still get compiling (stable) Swift.
 - **App Schema (#49)** macros `@AppEntity(schema:)` / `@AppIntent(schema:)` / `@AppEnum(schema:)` are **iOS 27** external macros (`AppIntentsMacros`). The macro is lenient: it adds the conformance (`@attached(extension, conformances: AppEntity, …)`) and tolerates a minimal entity body + a redundant explicit `: AppEntity`. Schema-specific properties are optional/synthesized, so an existing generated entity compiles by just prefixing the macro. Schema accessor form is `.<domain>.<schema>` (e.g. `.messages.message`, `.messages.setMessageReadStatus`).
 - **Semantic indexing (#50)**: `@Property(indexingKey:)` takes a `PartialKeyPath<CSSearchableItemAttributeSet>` (e.g. `\.contentDescription`) and is **iOS 18.4** (stable SDK, not iOS 27) — so it ships as a normal `@available(iOS 18.4, *)` feature, not behind `#if`. `@Property` ≡ `EntityProperty` (typealias); its bare `init()` is `@available(*, unavailable)`, so always emit at least `@Property(title:)`.
 - `IndexedEntityQuery` (re-indexing: `reindexEntities`/`reindexAllEntities`) is iOS 27 (deferred). `@ComputedProperty`/`@DeferredProperty` are iOS 26 macros (deferred).
+- **Richer parameter types (#53)**: `Swift.Duration` and `Foundation.PersonNameComponents` gain their `AppIntents._IntentValue` conformance (`extension … : @retroactive …, AppIntents._IntentValue`) **only in the iOS 27 SDK** — absent from the stable SDK (verified by diffing the Xcode 27 beta vs Xcode 26 `.swiftinterface`). So native `Duration` params **must** be `#if`-gated (no `@available` — the conformance symbol doesn't exist on stable). The compile-everywhere fallback is `Measurement<UnitDuration>`, which *does* carry an `IntentParameter` initializer on both SDKs. `Duration.components` is `(seconds: Int64, attoseconds: Int64)`; 1 µs == 1e12 attoseconds. `@Parameter(title:)` alone is valid for both `Duration` and `Measurement<UnitDuration>`. `PersonNameComponents`/`@UnionValue`/`EntityCollection` deferred (need a Dart-side representation, not pure codegen).
 
 **How to verify (the load-bearing check)**: golden/unit tests only assert "the strings
 I emitted came out"; they pass while emitting Swift that won't compile. Always

--- a/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
+++ b/packages/app_intents_codegen/lib/src/experimental/experimental_features.dart
@@ -19,7 +19,12 @@ enum ExperimentalFeature {
   appSchema('app-schema'),
 
   /// Entity ownership (#55): `OwnershipProvidingEntity` conformance.
-  ownership('ownership');
+  ownership('ownership'),
+
+  /// Richer parameter types (#53): native `Duration` parameters. Without this
+  /// feature a `Duration` parameter falls back to `Measurement<UnitDuration>`,
+  /// which the stable SDK supports.
+  richTypes('rich-types');
 
   const ExperimentalFeature(this.flag);
 

--- a/packages/app_intents_codegen/lib/src/generator/dart_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/dart_generator.dart
@@ -189,6 +189,17 @@ $fromMapParams    );
       }
     }
 
+    // Duration is serialized on the Swift side as an Int of microseconds (the
+    // native `Duration` and the `Measurement<UnitDuration>` fallback both reduce
+    // to the same value), so the Dart side is branch-agnostic.
+    if (baseType == 'Duration') {
+      if (isNullable) {
+        return "map['${param.fieldName}'] != null ? Duration(microseconds: map['${param.fieldName}'] as int) : null";
+      } else {
+        return "Duration(microseconds: map['${param.fieldName}'] as int)";
+      }
+    }
+
     if (baseType == 'double') {
       if (isNullable) {
         return "(map['${param.fieldName}'] as num?)?.toDouble()";
@@ -215,6 +226,14 @@ $fromMapParams    );
         return "params['${param.fieldName}'] != null ? DateTime.tryParse(params['${param.fieldName}']!) : null";
       } else {
         return "DateTime.parse(params['${param.fieldName}']!)";
+      }
+    }
+
+    if (baseType == 'Duration') {
+      if (isNullable) {
+        return "params['${param.fieldName}'] != null ? Duration(microseconds: int.parse(params['${param.fieldName}']!)) : null";
+      } else {
+        return "Duration(microseconds: int.parse(params['${param.fieldName}']!))";
       }
     }
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -102,7 +102,17 @@ class SwiftGenerator {
   }
 
   /// Writes a parameter declaration to the buffer.
-  void _writeParameter(StringBuffer buffer, IntentParamInfo param) {
+  ///
+  /// When [nativeDuration] is true (the experimental WWDC26 `#if` branch with
+  /// the `rich-types` feature enabled), a Dart `Duration` parameter is emitted
+  /// as the native iOS 27 `Duration` type. Otherwise it falls back to
+  /// `Measurement<UnitDuration>`, which the stable SDK supports — so the default
+  /// and `#else` output always compiles.
+  void _writeParameter(
+    StringBuffer buffer,
+    IntentParamInfo param, {
+    bool nativeDuration = false,
+  }) {
     // File type parameters use IntentFile
     if (param.fileType != null) {
       final isNullable = param.isOptional || param.dartType.endsWith('?');
@@ -121,7 +131,7 @@ class SwiftGenerator {
     final swiftType =
         param.entityType ??
         param.enumType ??
-        dartTypeToSwiftType(param.dartType);
+        _swiftParameterType(param, nativeDuration: nativeDuration);
 
     // Build @Parameter annotation
     final paramParts = <String>['title: "${param.title}"'];
@@ -131,6 +141,27 @@ class SwiftGenerator {
     buffer.writeln('$_indent@Parameter(${paramParts.join(', ')})');
     buffer.writeln('${_indent}var ${param.fieldName}: $swiftType');
   }
+
+  /// The Swift `@Parameter` type for [param], accounting for the Duration
+  /// fallback. See [_writeParameter] for the [nativeDuration] semantics.
+  String _swiftParameterType(
+    IntentParamInfo param, {
+    required bool nativeDuration,
+  }) {
+    if (_isDurationParam(param)) {
+      final base = nativeDuration ? 'Duration' : 'Measurement<UnitDuration>';
+      return param.dartType.endsWith('?') ? '$base?' : base;
+    }
+    return dartTypeToSwiftType(param.dartType);
+  }
+
+  /// Whether [param] is a Dart `Duration` (nullable or not).
+  bool _isDurationParam(IntentParamInfo param) =>
+      param.dartType == 'Duration' || param.dartType == 'Duration?';
+
+  /// Whether [info] has any Duration parameter.
+  bool _hasDurationParams(IntentInfo info) =>
+      info.parameters.any(_isDurationParam);
 
   /// Returns the Swift expression to convert a parameter value for MethodChannel.
   ///
@@ -142,6 +173,12 @@ class SwiftGenerator {
     // File types: use pre-serialized variable
     if (param.fileType != null) {
       return '${param.fieldName}FileInfo';
+    }
+
+    // Duration types: use pre-serialized microseconds local (see
+    // [_writeDurationSerializations]), so both Swift type branches agree.
+    if (_isDurationParam(param)) {
+      return '${param.fieldName}Micros';
     }
 
     // Entity types: use .id
@@ -281,13 +318,17 @@ class SwiftGenerator {
   /// 1. URL scheme: urlScheme is set → opens URL
   /// 2. Cache: supportedModes is foreground without urlScheme → caches to UserDefaults
   /// 3. FlutterBridge: default → direct MethodChannel via FlutterBridge actor
-  void _writePerformMethod(StringBuffer buffer, IntentInfo info) {
+  void _writePerformMethod(
+    StringBuffer buffer,
+    IntentInfo info, {
+    bool nativeDuration = false,
+  }) {
     if (info.urlScheme != null) {
-      _writeUrlSchemePerformMethod(buffer, info);
+      _writeUrlSchemePerformMethod(buffer, info, nativeDuration);
     } else if (info.supportedModes == IntentModeType.foreground) {
-      _writeCachePerformMethod(buffer, info);
+      _writeCachePerformMethod(buffer, info, nativeDuration);
     } else {
-      _writeFlutterBridgePerformMethod(buffer, info);
+      _writeFlutterBridgePerformMethod(buffer, info, nativeDuration);
     }
   }
 
@@ -316,6 +357,47 @@ class SwiftGenerator {
     }
   }
 
+  /// Writes `<field>Micros` locals converting Duration parameters to an `Int`
+  /// number of microseconds.
+  ///
+  /// The native `Duration` (`#if` branch) and the `Measurement<UnitDuration>`
+  /// fallback have different APIs, but both reduce to the same microseconds
+  /// integer here — so the params dictionary and URL query items are identical
+  /// across branches and the Dart handler stays branch-agnostic
+  /// (`Duration(microseconds:)`).
+  void _writeDurationSerializations(
+    StringBuffer buffer,
+    IntentInfo info,
+    bool nativeDuration,
+  ) {
+    final indent2 = '$_indent$_indent';
+    for (final param in info.parameters) {
+      if (!_isDurationParam(param)) continue;
+      final name = param.fieldName;
+      final isNullable = param.isOptional || param.dartType.endsWith('?');
+      if (isNullable) {
+        final conv = _durationToMicrosExpression(r'$0', nativeDuration);
+        buffer.writeln(
+          '${indent2}let ${name}Micros: Int? = $name.map { $conv }',
+        );
+      } else {
+        final conv = _durationToMicrosExpression(name, nativeDuration);
+        buffer.writeln('${indent2}let ${name}Micros: Int = $conv');
+      }
+    }
+  }
+
+  /// The Swift expression converting [ref] (a `Duration` when [nativeDuration],
+  /// otherwise a `Measurement<UnitDuration>`) to an `Int` of microseconds.
+  String _durationToMicrosExpression(String ref, bool nativeDuration) {
+    if (nativeDuration) {
+      // 1 microsecond == 1_000_000_000_000 attoseconds.
+      return 'Int($ref.components.seconds) * 1_000_000 + '
+          'Int($ref.components.attoseconds / 1_000_000_000_000)';
+    }
+    return 'Int($ref.converted(to: .seconds).value * 1_000_000)';
+  }
+
   /// Writes the return statement (with optional dialog).
   void _writeReturnResult(StringBuffer buffer, IntentInfo info, String indent) {
     if (info.resultDialogTemplate != null) {
@@ -330,9 +412,14 @@ class SwiftGenerator {
   }
 
   /// Writes the perform method using FlutterBridge (MethodChannel).
-  void _writeFlutterBridgePerformMethod(StringBuffer buffer, IntentInfo info) {
+  void _writeFlutterBridgePerformMethod(
+    StringBuffer buffer,
+    IntentInfo info,
+    bool nativeDuration,
+  ) {
     _writePerformSignature(buffer, info);
     _writeFileParamSerializations(buffer, info);
+    _writeDurationSerializations(buffer, info, nativeDuration);
 
     final indent2 = '$_indent$_indent';
 
@@ -382,14 +469,19 @@ class SwiftGenerator {
   /// An intent that only restricts `executionTargets` or conforms to a schema
   /// (without long-running or cancellable) keeps its standard perform() for the
   /// configured execution mode.
-  void _writeExperimentalPerformMethod(StringBuffer buffer, IntentInfo info) {
+  void _writeExperimentalPerformMethod(
+    StringBuffer buffer,
+    IntentInfo info,
+    bool nativeDuration,
+  ) {
     if (!info.longRunning && !info.cancellable) {
-      _writePerformMethod(buffer, info);
+      _writePerformMethod(buffer, info, nativeDuration: nativeDuration);
       return;
     }
 
     _writePerformSignature(buffer, info);
     _writeFileParamSerializations(buffer, info);
+    _writeDurationSerializations(buffer, info, nativeDuration);
 
     final indent2 = '$_indent$_indent';
     final indent3 = '$_indent$_indent$_indent';
@@ -428,9 +520,14 @@ class SwiftGenerator {
   /// Caches intent parameters to UserDefaults via `setPendingAction()`,
   /// then returns `.result()`. The app opens in foreground, Flutter starts,
   /// and `processPendingActions()` delivers the cached action.
-  void _writeCachePerformMethod(StringBuffer buffer, IntentInfo info) {
+  void _writeCachePerformMethod(
+    StringBuffer buffer,
+    IntentInfo info,
+    bool nativeDuration,
+  ) {
     _writePerformSignature(buffer, info);
     _writeFileParamSerializations(buffer, info);
+    _writeDurationSerializations(buffer, info, nativeDuration);
 
     final indent2 = '$_indent$_indent';
 
@@ -470,7 +567,11 @@ class SwiftGenerator {
   }
 
   /// Writes the perform method using URL scheme execution.
-  void _writeUrlSchemePerformMethod(StringBuffer buffer, IntentInfo info) {
+  void _writeUrlSchemePerformMethod(
+    StringBuffer buffer,
+    IntentInfo info,
+    bool nativeDuration,
+  ) {
     final scheme = info.urlScheme!;
     final action = info.urlAction ?? _defaultAction(info.identifier);
     final indent2 = '$_indent$_indent';
@@ -490,6 +591,7 @@ class SwiftGenerator {
       buffer.writeln('${indent2}components.scheme = "$scheme"');
       buffer.writeln('${indent2}components.host = "$action"');
       buffer.writeln();
+      _writeDurationSerializations(buffer, info, nativeDuration);
       buffer.writeln('${indent2}var queryItems = [URLQueryItem]()');
 
       for (final param in info.parameters) {
@@ -535,6 +637,23 @@ class SwiftGenerator {
       buffer.writeln(
         '$_indent${_indent}queryItems.append(URLQueryItem(name: "${param.fieldName}", value: ${param.fieldName}.rawValue))',
       );
+      return;
+    }
+
+    // Duration types: use the pre-serialized microseconds local.
+    if (_isDurationParam(param)) {
+      final name = param.fieldName;
+      if (isNullable) {
+        buffer.writeln('$_indent${_indent}if let ${name}Micros {');
+        buffer.writeln(
+          '$_indent$_indent${_indent}queryItems.append(URLQueryItem(name: "$name", value: String(${name}Micros)))',
+        );
+        buffer.writeln('$_indent$_indent}');
+      } else {
+        buffer.writeln(
+          '$_indent${_indent}queryItems.append(URLQueryItem(name: "$name", value: String(${name}Micros)))',
+        );
+      }
       return;
     }
 
@@ -1294,7 +1413,17 @@ class SwiftGenerator {
   /// Whether [info] uses any experimental WWDC26 feature (execution control or
   /// App Schema), which triggers dual-branch emission.
   bool _usesExperimentalIntent(IntentInfo info) =>
-      _usesExperimentalExecution(info) || _usesExperimentalSchema(info);
+      _usesExperimentalExecution(info) ||
+      _usesExperimentalSchema(info) ||
+      _usesExperimentalRichTypes(info);
+
+  /// Whether [info] should emit the native `Duration` parameter form
+  /// (`rich-types` feature enabled and at least one Duration parameter). This
+  /// triggers dual-branch emission so the stable `#else` keeps the
+  /// `Measurement<UnitDuration>` fallback.
+  bool _usesExperimentalRichTypes(IntentInfo info) =>
+      experimental.isEnabled(ExperimentalFeature.richTypes) &&
+      _hasDurationParams(info);
 
   /// Whether [info] should emit the experimental WWDC26 execution-control form.
   ///
@@ -1340,6 +1469,10 @@ class SwiftGenerator {
 
     buffer.write('}');
   }
+  // NOTE: the stable body never emits native Duration; a Duration parameter
+  // here is always the `Measurement<UnitDuration>` fallback (nativeDuration
+  // defaults to false), so the default and `#else` output compiles on the
+  // released SDK.
 
   /// Generates the experimental WWDC26 intent struct.
   ///
@@ -1352,14 +1485,20 @@ class SwiftGenerator {
     final hasExecutionTargets =
         info.executionTargets != null && info.executionTargets!.isNotEmpty;
     final hasSchema = _usesExperimentalSchema(info);
+    final nativeDuration = _usesExperimentalRichTypes(info);
 
     final conformances = <String>['AppIntent'];
     if (info.longRunning) conformances.add('LongRunningIntent');
     if (info.cancellable) conformances.add('CancellableIntent');
 
-    // LongRunningIntent, IntentExecutionTargets and App Schema are iOS 27+;
-    // CancellableIntent on its own is iOS 26.4+.
-    final minVersion = (info.longRunning || hasExecutionTargets || hasSchema)
+    // LongRunningIntent, IntentExecutionTargets, App Schema and native
+    // `Duration` parameters are iOS 27+; CancellableIntent on its own is
+    // iOS 26.4+.
+    final minVersion =
+        (info.longRunning ||
+            hasExecutionTargets ||
+            hasSchema ||
+            nativeDuration)
         ? '27.0'
         : '26.4';
 
@@ -1386,10 +1525,10 @@ class SwiftGenerator {
     }
 
     _writeParameterSummary(buffer, info);
-    _writeIntentParameters(buffer, info);
+    _writeIntentParameters(buffer, info, nativeDuration: nativeDuration);
 
     buffer.writeln();
-    _writeExperimentalPerformMethod(buffer, info);
+    _writeExperimentalPerformMethod(buffer, info, nativeDuration);
 
     buffer.write('}');
   }
@@ -1429,11 +1568,15 @@ class SwiftGenerator {
   }
 
   /// Writes the `@Parameter` declarations when present.
-  void _writeIntentParameters(StringBuffer buffer, IntentInfo info) {
+  void _writeIntentParameters(
+    StringBuffer buffer,
+    IntentInfo info, {
+    bool nativeDuration = false,
+  }) {
     if (info.parameters.isEmpty) return;
     buffer.writeln();
     for (final param in info.parameters) {
-      _writeParameter(buffer, param);
+      _writeParameter(buffer, param, nativeDuration: nativeDuration);
     }
   }
 

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -1495,10 +1495,7 @@ class SwiftGenerator {
     // `Duration` parameters are iOS 27+; CancellableIntent on its own is
     // iOS 26.4+.
     final minVersion =
-        (info.longRunning ||
-            hasExecutionTargets ||
-            hasSchema ||
-            nativeDuration)
+        (info.longRunning || hasExecutionTargets || hasSchema || nativeDuration)
         ? '27.0'
         : '26.4';
 

--- a/packages/app_intents_codegen/test/analyzer/intent_analyzer_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/intent_analyzer_test.dart
@@ -151,7 +151,9 @@ void main() {
         final result = analyzer.analyze(findClass(library, 'StartTimerIntent'));
 
         expect(result, isNotNull);
-        final timer = result!.parameters.firstWhere((p) => p.fieldName == 'timer');
+        final timer = result!.parameters.firstWhere(
+          (p) => p.fieldName == 'timer',
+        );
         expect(timer.dartType, equals('Duration'));
         final snooze = result.parameters.firstWhere(
           (p) => p.fieldName == 'snooze',

--- a/packages/app_intents_codegen/test/analyzer/intent_analyzer_test.dart
+++ b/packages/app_intents_codegen/test/analyzer/intent_analyzer_test.dart
@@ -129,6 +129,36 @@ void main() {
         expect(messageParam.description, equals('The message to display'));
       });
 
+      test('captures Duration parameter types (#53)', () async {
+        final library = await resolveSource('''
+          import 'package:app_intents_annotations/app_intents_annotations.dart';
+
+          @IntentSpec(
+            identifier: 'com.example.startTimer',
+            title: 'Start Timer',
+          )
+          class StartTimerIntent extends IntentSpecBase {
+            @IntentParam(title: 'Timer')
+            final Duration timer;
+
+            @IntentParam(title: 'Snooze', isOptional: true)
+            final Duration? snooze;
+
+            StartTimerIntent({required this.timer, this.snooze});
+          }
+        ''');
+
+        final result = analyzer.analyze(findClass(library, 'StartTimerIntent'));
+
+        expect(result, isNotNull);
+        final timer = result!.parameters.firstWhere((p) => p.fieldName == 'timer');
+        expect(timer.dartType, equals('Duration'));
+        final snooze = result.parameters.firstWhere(
+          (p) => p.fieldName == 'snooze',
+        );
+        expect(snooze.dartType, equals('Duration?'));
+      });
+
       test('extracts urlScheme and urlAction when provided', () async {
         final library = await resolveSource('''
           import 'package:app_intents_annotations/app_intents_annotations.dart';

--- a/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
+++ b/packages/app_intents_codegen/test/experimental/experimental_features_test.dart
@@ -12,13 +12,22 @@ void main() {
         ExperimentalFeature.fromFlag('app-schema'),
         ExperimentalFeature.appSchema,
       );
+      expect(
+        ExperimentalFeature.fromFlag('rich-types'),
+        ExperimentalFeature.richTypes,
+      );
       expect(ExperimentalFeature.fromFlag('nope'), isNull);
     });
 
     test('allFlags lists every feature token', () {
       expect(
         ExperimentalFeature.allFlags,
-        containsAll(<String>['long-running', 'app-schema']),
+        containsAll(<String>[
+          'long-running',
+          'app-schema',
+          'ownership',
+          'rich-types',
+        ]),
       );
     });
   });

--- a/packages/app_intents_codegen/test/generator/dart_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/dart_generator_test.dart
@@ -187,6 +187,52 @@ void main() {
         expect(result, contains("DateTime.tryParse(params['dueDate']!)"));
       });
 
+      test('generates Params class with Duration parameters (#53)', () {
+        final intents = [
+          const IntentInfo(
+            className: 'StartTimerIntent',
+            identifier: 'com.example.startTimer',
+            title: 'Start Timer',
+            implementation: IntentImplementationType.dart,
+            parameters: [
+              IntentParamInfo(
+                fieldName: 'timer',
+                dartType: 'Duration',
+                title: 'Timer',
+                isOptional: false,
+              ),
+              IntentParamInfo(
+                fieldName: 'snooze',
+                dartType: 'Duration?',
+                title: 'Snooze',
+                isOptional: true,
+              ),
+            ],
+          ),
+        ];
+
+        final result = generator.generate(intents, []);
+
+        expect(result, contains('final Duration timer'));
+        expect(result, contains('final Duration? snooze'));
+        // Swift serializes Duration as an Int of microseconds.
+        expect(
+          result,
+          contains("Duration(microseconds: map['timer'] as int)"),
+        );
+        expect(result, contains("map['snooze'] != null"));
+        expect(
+          result,
+          contains("Duration(microseconds: map['snooze'] as int)"),
+        );
+        // fromQueryParameters
+        expect(
+          result,
+          contains("Duration(microseconds: int.parse(params['timer']!))"),
+        );
+        expect(result, contains("params['snooze'] != null"));
+      });
+
       test('generates handler using Params class with named parameters', () {
         final intents = [
           const IntentInfo(

--- a/packages/app_intents_codegen/test/generator/dart_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/dart_generator_test.dart
@@ -216,10 +216,7 @@ void main() {
         expect(result, contains('final Duration timer'));
         expect(result, contains('final Duration? snooze'));
         // Swift serializes Duration as an Int of microseconds.
-        expect(
-          result,
-          contains("Duration(microseconds: map['timer'] as int)"),
-        );
+        expect(result, contains("Duration(microseconds: map['timer'] as int)"));
         expect(result, contains("map['snooze'] != null"));
         expect(
           result,

--- a/packages/app_intents_codegen/test/generator/swift_generator_duration_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_duration_test.dart
@@ -4,8 +4,9 @@ import 'package:app_intents_codegen/src/models/intent_info.dart';
 import 'package:test/test.dart';
 
 /// A generator with every WWDC26 experimental feature enabled.
-SwiftGenerator _experimentalGenerator() =>
-    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
+SwiftGenerator _experimentalGenerator() => const SwiftGenerator(
+  experimental: ExperimentalFeatures(masterEnabled: true),
+);
 
 IntentInfo _intent({List<IntentParamInfo> parameters = const []}) => IntentInfo(
   className: 'StartTimerIntent',
@@ -40,7 +41,9 @@ void main() {
     group('default / fallback (rich-types OFF)', () {
       test('emits Measurement<UnitDuration> in a single struct, no #if', () {
         final result = const SwiftGenerator().generateAll(
-          intents: [_intent(parameters: [_duration])],
+          intents: [
+            _intent(parameters: [_duration]),
+          ],
         );
 
         expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
@@ -59,7 +62,9 @@ void main() {
           ),
         );
         final result = generator.generateAll(
-          intents: [_intent(parameters: [_duration])],
+          intents: [
+            _intent(parameters: [_duration]),
+          ],
         );
 
         expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
@@ -69,7 +74,9 @@ void main() {
 
       test('nullable Duration falls back to optional Measurement', () {
         final result = const SwiftGenerator().generateAll(
-          intents: [_intent(parameters: [_nullableDuration])],
+          intents: [
+            _intent(parameters: [_nullableDuration]),
+          ],
         );
 
         expect(result, contains('var timer: Measurement<UnitDuration>?'));
@@ -86,7 +93,9 @@ void main() {
     group('rich-types ON (dual-branch)', () {
       test('native Duration in #if, Measurement fallback in #else', () {
         final result = _experimentalGenerator().generateAll(
-          intents: [_intent(parameters: [_duration])],
+          intents: [
+            _intent(parameters: [_duration]),
+          ],
         );
 
         expect(result, contains('#if APP_INTENTS_WWDC26'));

--- a/packages/app_intents_codegen/test/generator/swift_generator_duration_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_duration_test.dart
@@ -1,0 +1,122 @@
+import 'package:app_intents_codegen/src/experimental/experimental_features.dart';
+import 'package:app_intents_codegen/src/generator/swift_generator.dart';
+import 'package:app_intents_codegen/src/models/intent_info.dart';
+import 'package:test/test.dart';
+
+/// A generator with every WWDC26 experimental feature enabled.
+SwiftGenerator _experimentalGenerator() =>
+    const SwiftGenerator(experimental: ExperimentalFeatures(masterEnabled: true));
+
+IntentInfo _intent({List<IntentParamInfo> parameters = const []}) => IntentInfo(
+  className: 'StartTimerIntent',
+  identifier: 'com.example.startTimer',
+  title: 'Start Timer',
+  implementation: IntentImplementationType.dart,
+  parameters: parameters,
+);
+
+const _duration = IntentParamInfo(
+  fieldName: 'timer',
+  dartType: 'Duration',
+  title: 'Timer',
+  isOptional: false,
+);
+
+const _nullableDuration = IntentParamInfo(
+  fieldName: 'timer',
+  dartType: 'Duration?',
+  title: 'Timer',
+  isOptional: true,
+);
+
+const _fallbackMicros =
+    'let timerMicros: Int = Int(timer.converted(to: .seconds).value * 1_000_000)';
+const _nativeMicros =
+    'let timerMicros: Int = Int(timer.components.seconds) * 1_000_000 + '
+    'Int(timer.components.attoseconds / 1_000_000_000_000)';
+
+void main() {
+  group('SwiftGenerator (#53 Duration parameters)', () {
+    group('default / fallback (rich-types OFF)', () {
+      test('emits Measurement<UnitDuration> in a single struct, no #if', () {
+        final result = const SwiftGenerator().generateAll(
+          intents: [_intent(parameters: [_duration])],
+        );
+
+        expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+        expect(result, contains('var timer: Measurement<UnitDuration>'));
+        // The native Duration type must never leak into the default output.
+        expect(result, isNot(contains('var timer: Duration\n')));
+        expect(result, contains(_fallbackMicros));
+        expect(result, contains('"timer": timerMicros'));
+      });
+
+      test('master on but rich-types not selected keeps the fallback', () {
+        final generator = const SwiftGenerator(
+          experimental: ExperimentalFeatures(
+            masterEnabled: true,
+            enabled: {ExperimentalFeature.appSchema},
+          ),
+        );
+        final result = generator.generateAll(
+          intents: [_intent(parameters: [_duration])],
+        );
+
+        expect(result, isNot(contains('#if APP_INTENTS_WWDC26')));
+        expect(result, contains('var timer: Measurement<UnitDuration>'));
+        expect(result, contains(_fallbackMicros));
+      });
+
+      test('nullable Duration falls back to optional Measurement', () {
+        final result = const SwiftGenerator().generateAll(
+          intents: [_intent(parameters: [_nullableDuration])],
+        );
+
+        expect(result, contains('var timer: Measurement<UnitDuration>?'));
+        expect(
+          result,
+          contains(
+            'let timerMicros: Int? = timer.map { '
+            'Int(\$0.converted(to: .seconds).value * 1_000_000) }',
+          ),
+        );
+      });
+    });
+
+    group('rich-types ON (dual-branch)', () {
+      test('native Duration in #if, Measurement fallback in #else', () {
+        final result = _experimentalGenerator().generateAll(
+          intents: [_intent(parameters: [_duration])],
+        );
+
+        expect(result, contains('#if APP_INTENTS_WWDC26'));
+        expect(result, contains('#else'));
+        expect(result, contains('#endif'));
+
+        final ifBranch = result.substring(
+          result.indexOf('#if'),
+          result.indexOf('#else'),
+        );
+        final elseBranch = result.substring(
+          result.indexOf('#else'),
+          result.indexOf('#endif'),
+        );
+
+        // #if branch: native iOS 27 Duration, components-based microseconds.
+        expect(ifBranch, contains('@available(iOS 27.0, *)'));
+        expect(ifBranch, contains('var timer: Duration'));
+        expect(ifBranch, contains(_nativeMicros));
+        expect(ifBranch, isNot(contains('Measurement<UnitDuration>')));
+
+        // #else branch: stable Measurement fallback at iOS 17.
+        expect(elseBranch, contains('@available(iOS 17.0, *)'));
+        expect(elseBranch, contains('var timer: Measurement<UnitDuration>'));
+        expect(elseBranch, contains(_fallbackMicros));
+
+        // Both branches serialize to the same branch-agnostic Dart wire value.
+        expect(ifBranch, contains('"timer": timerMicros'));
+        expect(elseBranch, contains('"timer": timerMicros'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #62. The first slice of WWDC26 issue #53 (richer parameter types): native `Duration` `@IntentParam` support, opt-in and compile-verified.

## What

- **Default / `#else` fallback**: a Dart `Duration` parameter maps to `Measurement<UnitDuration>` — supported on the stable SDK, so it compiles everywhere and Shortcuts shows a real duration picker.
- **`--experimental=rich-types`** (new feature flag): upgrades to the **native iOS 27 `Duration`** type inside `#if APP_INTENTS_WWDC26` (dual-branch struct, like #52).
- Both branches pre-serialize to a normalized `<field>Micros: Int` microseconds local (native via `.components.seconds`/`.attoseconds`; fallback via `.converted(to: .seconds).value`), so the params dict, URL query, and Dart side are **branch-agnostic**. Dart deserializes with `Duration(microseconds:)`. Same `<field>…` pattern as IntentFile's `<field>FileInfo`.

## Why `#if`-gated, not `@available`

`Swift.Duration` gains its `AppIntents._IntentValue` conformance **only in the iOS 27 SDK** — it's absent from the stable SDK (verified by diffing the Xcode 27 beta vs Xcode 26 `.swiftinterface`). A missing conformance is a symbol-existence problem, not a runtime-OS problem, so `@available` can't guard it. The native `Duration` type therefore must never leak into the default output, and `rich-types` triggers dual-branch emission only when an intent actually has a `Duration` param.

## Verification

- codegen + annotation tests green (incl. new generator / dart-generator / analyzer Duration tests); `dart analyze` clean.
- **Dual-branch `swiftc -typecheck` green** against the Xcode 27 beta iOS 27 SDK — fallback branch (no flag) and native branch (`-D APP_INTENTS_WWDC26`) both compile.
- Default (non-Duration) output unchanged byte-for-byte (existing golden tests pass).

## Deferred (need a Dart representation / handler-I/F design — not pure codegen)

`PersonNameComponents` params (no equivalent Dart type), `@UnionValue`, `EntityCollection<T>`. Tracked under #53 / #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of #53 (richer parameter types) — the Duration slice. #53 is closed by #66, the final slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation for `Duration` parameter mapping strategy and serialization.

* **New Features**
  * Added `Duration` parameter support for app intents with automatic microsecond serialization.
  * Introduced experimental "rich-types" feature flag for native iOS 27 `Duration` support with fallback compatibility.

* **Tests**
  * Added comprehensive test coverage for `Duration` parameter serialization in code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->