### PR TITLE
chore(android): migrate Gradle Kotlin DSL to compilerOptions + refresh docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,19 @@ Options:
 - KSP compiler cannot handle `Map<String, Any?>` as `@AppFunction` return type — use `String` (JSON)
 - KSP version: KSP1 used the `{kotlin-version}-{ksp-version}` concatenation (e.g., `2.2.20-2.0.4`); KSP2 (current) uses a standalone version (e.g., `2.3.9`) — match whatever the example app's `settings.gradle.kts` declares
 - Three Jetpack artifacts: `appfunctions`, `appfunctions-service`, `appfunctions-compiler`
+- **Kotlin version is gated by the AppFunctions/KSP toolchain — do NOT blindly accept
+  Dependabot Kotlin bumps.** The example app pins Kotlin **2.2.20** (KSP `2.3.9`,
+  `appfunctions:1.0.0-alpha09`). Bumping to **Kotlin 2.4.0** (released 2026-06-03, after
+  both KSP 2.3.9 and alpha09) fails `:app:kspDebugKotlin` with
+  `Can't escape identifier `$Android:appDebug_FunctionComponentRegistry` because it
+  contains illegal characters: :` — the AppFunctions compiler emits a colon-bearing
+  identifier that Kotlin 2.4.0's stricter escaping rejects, inside KSP's `KspAAWorkerAction`
+  (Analysis API). Both KSP (2.3.9) and appfunctions (alpha09) are already the latest
+  releases, so there is no toolchain knob to fix it — it needs a future KSP **or**
+  appfunctions release that supports Kotlin 2.4.0. **Decision rule**: hold/close any
+  Kotlin bump PR until a newer KSP or appfunctions alpha lands; re-test the bump then.
+  (Verified via bisection in PR #48 — the build-script DSL migration below is independent
+  and lands fine on 2.2.20.)
 
 ### Entity Identifier Consistency
 The `entityIdentifier` used in Swift's FlutterBridge calls **must match** the `identifier` from `@EntitySpec` (used in Dart's `registerEntityQueryHandler` / `registerSuggestedEntitiesHandler`). Use `info.identifier` (e.g., `"com.example.taskapp.TaskEntity"`), **not** `info.className` (e.g., `"TaskEntitySpec"`).
@@ -525,7 +538,7 @@ if #available(iOS 17.0, *) {
 7. **(WWDC26 experimental only)** When emitting experimental features, wire the additional bridges in AppDelegate: `setValueQueryExecutor` (#51), `AppIntentsPlugin.relevantEntitiesDonationForwarder` + the generated `register<Entity>RelevantEntitiesDonator()` (#55), and `AppIntentsPlugin.onscreenEntityBinder` (#56). See `docs/usage.md` → "Native wiring for experimental bridges". Gate the iOS-27 ones with `#if APP_INTENTS_WWDC26`.
 
 ### Android App Integration Steps
-1. Use AGP 9.1.0+ / Gradle 9.3.1+ (required by `appfunctions:1.0.0-alpha09`)
+1. Use AGP 9.2.1 / Gradle 9.5.1 (example app's current toolchain; `appfunctions:1.0.0-alpha09` needs AGP 9.1.0+ / Gradle 9.3.1+ at minimum)
 2. Add KSP plugin to `android/settings.gradle.kts`:
    ```kotlin
    id("com.android.application") version "9.2.1" apply false
@@ -541,6 +554,19 @@ if #available(iOS 17.0, *) {
    - Apply `kotlin-android` and KSP plugins, set `compileSdk = 37`, `targetSdk = 37`, `minSdk = 36`
    - Add AppFunctions dependencies (`appfunctions`, `appfunctions-service`, `appfunctions-compiler`)
    - Add KSP arg: `ksp { arg("appfunctions:aggregateAppFunctions", "true") }`
+   - **Set the JVM target via the `compilerOptions` DSL, not `kotlinOptions`** — the
+     legacy `android { kotlinOptions { jvmTarget = ... } }` accessor is an ERROR-level
+     deprecation under modern Kotlin Gradle plugins (it fails the build-script
+     compilation, not just warns). Use a top-level `kotlin {}` block instead:
+     ```kotlin
+     import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+     // ...
+     kotlin {
+         compilerOptions {
+             jvmTarget = JvmTarget.JVM_17
+         }
+     }
+     ```
 5. Run `make kotlin-gen` to generate Kotlin code
 6. Wire AppFunctionsBridge in MainActivity:
 ```kotlin

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -16,10 +18,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     defaultConfig {
         applicationId = "com.example.app"
         minSdk = 36
@@ -34,6 +32,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## 概要

PR #48（Dependabot: Kotlin 2.4.0 bump）の検証中に判明した、独立して取り込む価値のある変更を切り出した PR です。

## 背景

PR #48 の CI（Android plugin build）失敗を調査したところ、**2 つの独立した問題**が重なっていました:

1. **ビルドスクリプトの deprecated DSL（本 PR で修正）** — `android { kotlinOptions { jvmTarget } }` は modern Kotlin Gradle plugin で **ERROR レベルの deprecation**（警告ではなくビルドスクリプトのコンパイルが失敗）。
2. **Kotlin 2.4.0 × KSP/appfunctions の非互換（本 PR の対象外）** — KSP 2.3.9 / `appfunctions:1.0.0-alpha09`（どちらも最新）が Kotlin 2.4.0（2026-06-03 リリース、両者より後発）に未追従。`:app:kspDebugKotlin` がコロン入り識別子のエスケープで落ちる。これは上流の対応待ち。

①は Kotlin 版に依存せず修正でき、**Kotlin 2.2.20 のままビルドが通る**ため、本 PR として切り出しました。

## 変更内容

- `app/android/app/build.gradle.kts`: `kotlinOptions`/`jvmTarget` → トップレベル `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`
- `CLAUDE.md`:
  - AppFunctions Gotchas に **Kotlin 2.4.0 ブロッカー**と「Dependabot Kotlin bump を鵜呑みにしない」判断ルールを追記
  - `compilerOptions` DSL を Android 統合手順に明記
  - AGP/Gradle のバージョン参照を現行ツールチェインに更新

## 検証

- `flutter build apk --debug` → ✅ green（Kotlin 2.2.20）
- 切り分け: 2.4.0 + 本 DSL 移行 → DSL エラーは解消するが KSP エラーで失敗（＝①と②が独立であることを確認）

## 関連

- #48（Kotlin 2.4.0 bump）は上流ツールチェイン未対応のためクローズ予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android development toolchain setup guidance with refreshed build tool version requirements
  * Added Kotlin version compatibility notes and build reliability warnings

* **Chores**
  * Updated Gradle and build plugin version baselines
  * Modernized Kotlin compiler target configuration approach for improved build compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->