### PR TITLE
chore: release v0.12.0 (matsudate WWDC26 review #4 follow-ups)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -51,11 +51,11 @@ flutter_intents/
 
 ```yaml
 dependencies:
-  app_intents: ^0.11.0
-  app_intents_annotations: ^0.11.0
+  app_intents: ^0.12.0
+  app_intents_annotations: ^0.12.0
 
 dev_dependencies:
-  app_intents_codegen: ^0.11.0
+  app_intents_codegen: ^0.12.0
   build_runner: ^2.4.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ flutter_intents/
 
 ```yaml
 dependencies:
-  app_intents: ^0.11.0
-  app_intents_annotations: ^0.11.0
+  app_intents: ^0.12.0
+  app_intents_annotations: ^0.12.0
 
 dev_dependencies:
-  app_intents_codegen: ^0.11.0
+  app_intents_codegen: ^0.12.0
   build_runner: ^2.4.0
 ```
 

--- a/packages/app_intents/CHANGELOG.md
+++ b/packages/app_intents/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.0
+
+- New API `AppIntents().donateIntent(identifier, params)` (#55): wraps `AppIntent.donate()` (stable iOS 16+) so the Dart side can record an executed intent for Siri / Apple Intelligence to learn from. The call is forwarded through `AppIntentsPlugin.intentDonationForwarder` (set in AppDelegate, mirroring `relevantEntitiesDonationForwarder`) to `FlutterBridge.shared.donateIntent`, which invokes the per-intent reverse-executor emitted by `@IntentSpec(donatable: true)` codegen. iOS-only; a no-op on other platforms.
+- iOS native:
+  - `AppIntentsPlugin.intentDonationForwarder` static hook for AppDelegate wiring. The `donateIntent` MethodChannel case returns `DONATION_NOT_CONFIGURED` when the forwarder is not set.
+  - `FlutterBridge.shared.registerIntentDonator(intentIdentifier:_:)` / `donateIntent(intentIdentifier:params:)` / `hasIntentDonator(for:)`; the donators dictionary is cleared by `clearExecutors()` alongside the other executor slots.
+- Docs (`docs/usage.md`): adds the `intentDonationForwarder` wiring example next to the existing `relevantEntitiesDonationForwarder` block, plus the matching `register<Intent>Donator()` call site.
+
 ## 0.11.0
 
 - WWDC26 experimental bridges (opt-in; exercised only when experimental Swift generation is enabled):

--- a/packages/app_intents/pubspec.yaml
+++ b/packages/app_intents/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_intents
 description: Flutter plugin for iOS App Intents and Android AppFunctions integration. Enables Siri, Shortcuts, Spotlight, and AI agent support.
-version: 0.11.0
+version: 0.12.0
 homepage: https://github.com/touyou/flutter_intents
 repository: https://github.com/touyou/flutter_intents
 issue_tracker: https://github.com/touyou/flutter_intents/issues

--- a/packages/app_intents_annotations/CHANGELOG.md
+++ b/packages/app_intents_annotations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.0
+
+- `@IntentSpec(donatable: true)` — opt-in for `AppIntent.donate()` so Siri / Apple Intelligence learns the user performed the action in-app (#55). Inert unless the `donation` experimental feature is enabled in `app_intents_codegen`. MVP restricts to primitive parameter types (`String` / `int` / `double` / `bool` / `DateTime`, optionals allowed); entity / file / enum / union / collection params are rejected at codegen time.
+- `@IntentParam(useValueState: true)` — opt-in for `IntentParameter.ValueState` (`@available(iOS 18.2, *)` **stable** — no `#if` gating required). Distinguishes `unset` / `set` / `cleared` for an optional update parameter so the Dart handler can tell "don't touch" from "explicitly cleared." Only valid on a nullable Dart type; analyzer rejects use on non-optional params.
+- `AppSchemas.system.searchInApp` — typed accessor for the iOS 27 system search-in-app schema (iOS 17 used `.system.search`; iOS 27 renamed it). The iOS-17 identifier remains reachable via `AppSchemas.of(AppSchemaDomain.system, 'search')`. Also adds `AppSchemas.system.open`.
+
 ## 0.11.0
 
 - WWDC26 App Intents annotation surfaces (opt-in; inert unless experimental code generation is enabled in `app_intents_codegen`):

--- a/packages/app_intents_annotations/pubspec.yaml
+++ b/packages/app_intents_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_intents_annotations
 description: Annotations for defining iOS App Intents in Flutter. Use with app_intents and app_intents_codegen.
-version: 0.11.0
+version: 0.12.0
 homepage: https://github.com/touyou/flutter_intents
 repository: https://github.com/touyou/flutter_intents
 issue_tracker: https://github.com/touyou/flutter_intents/issues

--- a/packages/app_intents_codegen/CHANGELOG.md
+++ b/packages/app_intents_codegen/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.0
+
+- `@IntentSpec(donatable: true)` (#55, requires `--experimental=donation`): emits a `#if APP_INTENTS_WWDC26`-gated `register<Intent>Donator()` reverse-executor that reconstructs the concrete intent from a `[String: Any]` params dict and calls `intent.donate()` (stable iOS 16+). Analyzer enforces the MVP primitive-only contract; rejects `entityType` / `enumType` / `fileType` / `entityCollectionType` / `@UnionValue` / non-primitive Dart types at codegen time.
+- `@IntentParam(useValueState: true)` (#52): emits `if #available(iOS 18.2, *) { switch $field.valueState { … @unknown default … } }` in `perform()` and adds a sibling `"<field>State": "unset" | "cleared" | "set"` entry to the wire dict. The state key is added via `if let` in **both** FlutterBridge and cache-mode emit paths, so it is absent on iOS < 18.2 and the Dart handler can distinguish "no state info" from a present state. Analyzer rejects opt-in on non-optional Dart params. The Swift output uses `@unknown default` to future-proof against Swift 6's non-frozen enum errors. No experimental flag — this is a normal feature (the SDK symbol is stable iOS 18.2).
+- `AppSchemas.system.searchInApp` — codegen consumes the schema string verbatim through the existing `@AppIntent(schema:)` / `@AppEntity(schema:)` macro emission (the `app-schema` experimental gate is unchanged); no codegen change beyond the typed accessor that lives in `app_intents_annotations`.
+- Bumps `app_intents_annotations` dependency to `^0.12.0`.
+
 ## 0.11.0
 
 - WWDC26 experimental code generation (opt-in, default OFF). Master switch `--experimental-wwdc26` + per-feature `--experimental=<flag>` (`app-schema`, `ownership`, `long-running`, `rich-types`, `value-query`, `value-representation`, `donation`). Experimental Swift is emitted inside `#if APP_INTENTS_WWDC26` with a mandatory stable `#else` fallback, so released-SDK builds (without the flag) still compile.

--- a/packages/app_intents_codegen/pubspec.yaml
+++ b/packages/app_intents_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_intents_codegen
 description: Code generator for Flutter AppIntents. Produces Swift and Dart code from @IntentSpec and @EntitySpec annotations.
-version: 0.11.0
+version: 0.12.0
 homepage: https://github.com/touyou/flutter_intents
 repository: https://github.com/touyou/flutter_intents
 issue_tracker: https://github.com/touyou/flutter_intents/issues
@@ -24,7 +24,7 @@ dependencies:
   glob: ^2.1.0
   path: ^1.9.0
   yaml: ^3.1.0
-  app_intents_annotations: ^0.11.0
+  app_intents_annotations: ^0.12.0
 
 executables:
   generate_swift: generate_swift


### PR DESCRIPTION
## Summary

3 パッケージを **v0.12.0** に揃えるリリース PR。直前に merge した #73 の matsudate WWDC 2026 review #4 follow-ups（`@IntentSpec(donatable:)` / `@IntentParam(useValueState:)` / `AppSchemas.system.searchInApp` + deferred punch list）と、その PR で受けたレビュー修正を同梱します。

## Related issues

- Refs #59 (WWDC26 残課題)
- Bundles #73 (feature) into the released version

## Type of change

- [x] Other: maintainer release commit per `RELEASING.md`

## Affected packages

- [x] `app_intents` 0.11.0 → 0.12.0
- [x] `app_intents_annotations` 0.11.0 → 0.12.0
- [x] `app_intents_codegen` 0.11.0 → 0.12.0 (dep on annotations also bumped)
- [x] `README.md` / `README.ja.md` Quick Start dependency block

## Versioning rationale

Per `RELEASING.md`: new features → MINOR bump (`0.11.0` → `0.12.0`). The three new public API surfaces (`donateIntent`, `@IntentSpec(donatable:)`, `@IntentParam(useValueState:)`) are additive and non-breaking.

## Test plan

Pre-flight checks (from `RELEASING.md`):

- [x] `main` is green (PR #73 merged with all 10 CI checks passing)
- [x] All three packages have a `0.12.0` heading in `CHANGELOG.md` summarising the changes
- [x] Three pubspec.yaml versions and the codegen `app_intents_annotations` dep all aligned at `0.12.0`
- [x] README quick-start dependency block bumped

Post-merge (maintainer):

- [ ] `dart pub publish --dry-run` in each of the 3 packages (annotations → codegen → plugin)
- [ ] `dart pub publish` in dependency order (annotations → codegen → plugin)
- [ ] `git tag v0.12.0 && git push origin main v0.12.0`
- [ ] GitHub Release from the tag pasting the combined changelog entries

## Checklist

- [x] Tests added or updated where applicable _(landed via #73)_
- [x] `make test` passes locally _(verified via #73 CI)_
- [x] `dart analyze` / `flutter analyze` clean _(verified via #73 CI)_
- [x] Public API changes are reflected in the relevant `CHANGELOG.md`
- [x] User-visible doc changes mirrored in both `README.md` and `README.ja.md` (Quick Start bumped together)
- [x] `CLAUDE.md` updated _(landed via #73)_
- [x] Generated code regenerated _(landed via #73 — example app's Swift is byte-identical due to opt-in design)_
- [x] Maintainer-handled version bump per `RELEASING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S85Uds161q2itsUAyzy192