### PR TITLE
fix(codegen): normalize entity id property to `id` for AppEntity conformance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,11 +312,26 @@ The Dart mirror of the *inner* key is `AppIntentsEntityCacheKey.forEntity`.
 literally named `id`, Swift infers `Identifiable.ID == ObjectIdentifier` and the
 conformance fails with a confusing `'ObjectIdentifier' does not conform to
 'EntityIdentifierConvertible'`. The Dart `@EntityId` field name is arbitrary, so
-`WidgetSwiftGenerator` normalizes it (`_swiftPropertyName`) and passes the Dart
-name separately as the cached-payload `idKey:`; it also rejects a *non-id* role
-field named `id`, which would collide with that rename. **`SwiftGenerator` (the app-target
-generator) does not yet do this** — a non-`id` `@EntityId` produces output that
-does not compile. Tracked separately.
+**both Swift generators normalize it to `id`** via their own `_swiftPropertyName`
+helper, and both reject a *non-id* role field named `id`, which would collide
+with that rename:
+
+- `WidgetSwiftGenerator` — passes the Dart name separately as the cached-payload
+  `idKey:`.
+- `SwiftGenerator` (app target) — the Dart name survives only as the
+  cache/dictionary key (`dict["teamId"]`), which is what the Dart cache
+  projection writes.
+
+When touching `SwiftGenerator`:
+
+- Use `_swiftPropertyName(prop)` for any new site that emits an entity stored
+  property, initializer label, or `self.x = x` assignment. Never emit
+  `prop.fieldName` directly for the id-role property.
+- Sites reading the identifier off a Swift value (`$0.id`, `entity.id`, `team.id`
+  in intent param serialization) hardcode `id` — that is correct, not a bug.
+
+Golden string tests passed the entire time this was broken, because they only
+assert `contains(...)`. **Verify entity changes with `swiftc -typecheck`.**
 
 ### MethodChannel Type Serialization
 MethodChannel only supports specific types. Non-supported types need conversion:

--- a/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
+++ b/packages/app_intents_codegen/lib/src/generator/swift_generator.dart
@@ -1100,6 +1100,7 @@ class SwiftGenerator {
   }
 
   void _generateEntityBody(StringBuffer buffer, EntityInfo info) {
+    _validateIdPropertyName(info);
     if (_usesExperimentalEntitySchema(info)) {
       // App Schema (#49) is iOS 27+: the entity, its query and extensions all
       // move to iOS 27 in the experimental branch. The #else branch keeps the
@@ -1360,12 +1361,8 @@ class SwiftGenerator {
     StringBuffer buffer,
     EntityInfo info,
   ) {
-    final idField =
-        info.properties
-            .where((p) => p.role == EntityPropertyRole.id)
-            .firstOrNull
-            ?.fieldName ??
-        'id';
+    // Reads the Swift stored property, which is always `id`.
+    const idField = 'id';
     final titleField =
         info.properties
             .where((p) => p.role == EntityPropertyRole.title)
@@ -1545,6 +1542,37 @@ class SwiftGenerator {
     }
   }
 
+  /// The Swift stored-property name for [prop].
+  ///
+  /// `AppEntity` refines `Identifiable`, which requires a property literally
+  /// named `id`; the Dart field backing `@EntityId` may be called anything
+  /// (`teamId`, `uuid`, ...). So the identifier property is always emitted as
+  /// `id` and the Dart field name survives only as the cache/dictionary key
+  /// (see [_writeEntityDictMapping]). Every other property keeps its Dart name.
+  String _swiftPropertyName(EntityPropertyInfo prop) =>
+      prop.role == EntityPropertyRole.id ? 'id' : prop.fieldName;
+
+  /// Rejects the one case [_swiftPropertyName] cannot normalize: the `@EntityId`
+  /// field is named something other than `id`, while a *different* property is
+  /// literally named `id`. Normalizing would emit two `var id` declarations.
+  void _validateIdPropertyName(EntityInfo info) {
+    final idProp = info.properties
+        .where((p) => p.role == EntityPropertyRole.id)
+        .firstOrNull;
+    if (idProp == null || idProp.fieldName == 'id') return;
+    final collides = info.properties.any(
+      (p) => p.role != EntityPropertyRole.id && p.fieldName == 'id',
+    );
+    if (!collides) return;
+    throw InvalidGenerationSourceError(
+      'Entity `${info.className}` marks `${idProp.fieldName}` with @EntityId '
+      'but also declares a separate field named `id`. The generated Swift '
+      'entity must expose its identifier as `id` (AppEntity refines '
+      'Identifiable), so both fields would collide. Rename the non-identifier '
+      '`id` field, or move @EntityId onto it.',
+    );
+  }
+
   /// Writes the entity's stored properties, using `@Property(...)` for fields
   /// marked with `@EntityProperty`.
   void _writeEntityProperties(StringBuffer buffer, EntityInfo info) {
@@ -1553,7 +1581,7 @@ class SwiftGenerator {
       if (prop.exposeAsProperty) {
         buffer.writeln('$_indent${_propertyAttribute(prop)}');
       }
-      buffer.writeln('${_indent}var ${prop.fieldName}: $swiftType');
+      buffer.writeln('${_indent}var ${_swiftPropertyName(prop)}: $swiftType');
     }
   }
 
@@ -1588,18 +1616,18 @@ class SwiftGenerator {
     final params = ordered
         .map((prop) {
           final swiftType = dartTypeToSwiftType(prop.dartType);
+          final name = _swiftPropertyName(prop);
           if (prop.exposeAsProperty) {
-            return '${prop.fieldName}: $swiftType = '
+            return '$name: $swiftType = '
                 '${_defaultForSwiftType(swiftType, prop.fieldName)}';
           }
-          return '${prop.fieldName}: $swiftType';
+          return '$name: $swiftType';
         })
         .join(', ');
     buffer.writeln('${_indent}init($params) {');
     for (final prop in ordered) {
-      buffer.writeln(
-        '$_indent${_indent}self.${prop.fieldName} = ${prop.fieldName}',
-      );
+      final name = _swiftPropertyName(prop);
+      buffer.writeln('$_indent${_indent}self.$name = $name');
     }
     buffer.writeln('$_indent}');
   }
@@ -1761,7 +1789,8 @@ class SwiftGenerator {
       '${_indent}func entities(for identifiers: [String]) async throws -> [${info.className}] {',
     );
     if (cacheKey != null) {
-      final idField = idProp?.fieldName ?? 'id';
+      // Filtering reads the Swift stored property, which is always `id`.
+      const idField = 'id';
       buffer.writeln(
         '$_indent${_indent}if let cached = Self._readCachedEntities() {',
       );
@@ -1907,11 +1936,15 @@ class SwiftGenerator {
     EntityPropertyInfo? subtitleProp,
     EntityPropertyInfo? imageProp,
   ) {
-    final id = idProp?.fieldName ?? 'id';
+    // The dictionary key is the Dart field name (that is what the Dart cache
+    // projection writes); the Swift local and initializer label are normalized
+    // to `id` to match the stored property (see [_swiftPropertyName]).
+    final idKey = idProp?.fieldName ?? 'id';
+    const id = 'id';
     final title = titleProp?.fieldName ?? 'title';
 
     buffer.writeln(
-      '$_indent$_indent${_indent}guard let $id = dict["$id"] as? String,',
+      '$_indent$_indent${_indent}guard let $id = dict["$idKey"] as? String,',
     );
     buffer.writeln(
       '$_indent$_indent$_indent${_indent}let $title = dict["$title"] as? String else {',

--- a/packages/app_intents_codegen/test/generator/swift_generator_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_test.dart
@@ -2,6 +2,7 @@ import 'package:app_intents_codegen/src/generator/swift_generator.dart';
 import 'package:app_intents_codegen/src/models/entity_info.dart';
 import 'package:app_intents_codegen/src/models/enum_info.dart';
 import 'package:app_intents_codegen/src/models/intent_info.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -1828,7 +1829,7 @@ void main() {
         },
       );
 
-      test('uses the entity\'s id field name for the cache filter', () {
+      test('normalizes the id property to `id` for the cache filter', () {
         final entityInfo = EntityInfo(
           className: 'TaskEntity',
           identifier: 'com.example.task',
@@ -1851,10 +1852,118 @@ void main() {
 
         final result = generator.generateEntity(entityInfo);
 
+        // `AppEntity: Identifiable` requires a property literally named `id`,
+        // so the Swift stored property is normalized regardless of the Dart
+        // field name; filtering therefore reads `$0.id`.
+        expect(result, contains('var id: String'));
+        expect(result, isNot(contains('var taskId: String')));
         expect(
           result,
-          contains(r'cached.filter { identifiers.contains($0.taskId) }'),
+          contains(r'cached.filter { identifiers.contains($0.id) }'),
         );
+        // The Dart field name survives as the cache/dictionary key.
+        expect(result, contains(r'dict["taskId"]'));
+      });
+
+      test('emits an Identifiable-conforming `id` property for a non-`id` '
+          '@EntityId field name', () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          properties: [
+            EntityPropertyInfo(
+              fieldName: 'teamId',
+              dartType: 'String',
+              role: EntityPropertyRole.id,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'name',
+              dartType: 'String',
+              role: EntityPropertyRole.title,
+            ),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        // `AppEntity` refines `Identifiable`, which requires a property
+        // literally named `id`. Emitting `var teamId` instead produced
+        // "type 'TeamEntity' does not conform to protocol 'AppEntity'".
+        expect(result, contains('var id: String'));
+        expect(result, isNot(contains('var teamId: String')));
+        // Construction uses the normalized label...
+        expect(result, contains('TeamEntity(id: id, name: name)'));
+        // ...while the dictionary key stays the Dart field name, because
+        // that is what the Dart cache projection writes.
+        expect(result, contains(r'guard let id = dict["teamId"] as? String'));
+      });
+
+      test('throws when @EntityId is on a non-`id` field and another field is '
+          'named `id`', () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          properties: [
+            EntityPropertyInfo(
+              fieldName: 'teamId',
+              dartType: 'String',
+              role: EntityPropertyRole.id,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'name',
+              dartType: 'String',
+              role: EntityPropertyRole.title,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'id',
+              dartType: 'String',
+              role: EntityPropertyRole.none,
+              exposeAsProperty: true,
+              propertyTitle: 'Legacy Id',
+            ),
+          ],
+        );
+
+        // Normalizing would emit two `var id` declarations, so this must be
+        // a build-time error rather than silently non-compiling Swift.
+        expect(
+          () => generator.generateEntity(entityInfo),
+          throwsA(isA<InvalidGenerationSourceError>()),
+        );
+        expect(
+          () => generator.generateAll(entities: [entityInfo]),
+          throwsA(isA<InvalidGenerationSourceError>()),
+        );
+      });
+
+      test('leaves an already-`id` field name untouched', () {
+        final entityInfo = EntityInfo(
+          className: 'TeamEntity',
+          identifier: 'com.example.team',
+          title: 'Team',
+          pluralTitle: 'Teams',
+          properties: [
+            EntityPropertyInfo(
+              fieldName: 'id',
+              dartType: 'String',
+              role: EntityPropertyRole.id,
+            ),
+            EntityPropertyInfo(
+              fieldName: 'name',
+              dartType: 'String',
+              role: EntityPropertyRole.title,
+            ),
+          ],
+        );
+
+        final result = generator.generateEntity(entityInfo);
+
+        expect(result, contains('var id: String'));
+        expect(result, contains(r'guard let id = dict["id"] as? String'));
       });
     });
 

--- a/packages/app_intents_codegen/test/generator/swift_generator_value_representation_test.dart
+++ b/packages/app_intents_codegen/test/generator/swift_generator_value_representation_test.dart
@@ -55,8 +55,9 @@ void main() {
         );
         expect(result, contains('ValueRepresentation(exporting: { entity in'));
         expect(result, contains('IntentPerson('));
-        // Uses the entity's actual id/title field names, not literal id/title.
-        expect(result, contains('identifier: .applicationDefined(entity.uid)'));
+        // The id property is normalized to `id` (required by `Identifiable`);
+        // the title keeps its actual Dart field name.
+        expect(result, contains('identifier: .applicationDefined(entity.id)'));
         expect(result, contains('name: .displayName(entity.name)'));
         // handle has no default in the SDK initializer, so it is passed explicitly.
         expect(result, contains('handle: nil'));


### PR DESCRIPTION
## 問題

`AppEntity` は `Identifiable` を継承しており、**`id` という名前そのもの**の stored property を要求する。`SwiftGenerator._writeEntityProperties` は Dart のフィールド名をそのまま出力していたため、`@EntityId` が `id` 以外のフィールド（例 `teamId`）に付いていると、コンパイルできない Swift が生成されていた。

```
error: type 'TeamEntitySpec' does not conform to protocol 'AppEntity'
error: type 'ObjectIdentifier' does not conform to protocol 'EntityIdentifierConvertible'
error: type 'TeamEntitySpec' does not conform to protocol 'Identifiable'
```

これは #99 が CLAUDE.md に残した既知事項の解消にあたる:

> **`SwiftGenerator` (the app-target generator) does not yet do this** — a non-`id` `@EntityId` produces output that does not compile. Tracked separately.

## 修正

#99 の `WidgetSwiftGenerator._swiftPropertyName` と**同じ契約**を `SwiftGenerator` にも適用する。Swift 側の識別子プロパティは**常に `id`** として出力し、Dart のフィールド名は**キャッシュ/辞書のキーとしてのみ**残す（`dict["teamId"]`）。これは Dart 側のキャッシュ projection が書き出すキーと一致し、Widget 側が `idKey:` で Dart 名を別途渡しているのと同じ考え方。

この正規化はジェネレータの他の箇所とも整合する。entity 型の intent パラメータをシリアライズする箇所（`swift_generator.dart` の 247 / 599 / 633 / 638 / 652 / 663 / 964 行）は、もともと無条件に `<entity>.id` を出力しており、`id` 以外の名前とは元から噛み合っていなかった。

正規化できない唯一のケース（`@EntityId` が非 `id` フィールドにあり、かつ別に `id` という名前のフィールドが存在する）は、`var id` が二重に出て壊れるため `InvalidGenerationSourceError` を投げる。これも #99 の `WidgetSwiftGenerator` 側の衝突ガードと揃えてある。

### 変更点
- `_swiftPropertyName(prop)` を追加（id ロールのみ `id` に正規化）
- 反映: `_writeEntityProperties` / `_writeEntityInit` / `_writeEntityDictMapping` / `_writeQueryStruct` の `$0.id` / ValueRepresentation の `entity.id`
- `_validateIdPropertyName` で衝突を検出（`generateEntity` と `generateAll` の両経路が通る共有パスに設置）
- CLAUDE.md: #99 の「AppEntity requires an `id` property」節を、両ジェネレータ対応済みの内容に統合

## 既存テストが壊れた挙動を固定していた

`$0.taskId` と `entity.uid` を assert する既存テスト2件が、**コンパイルできない出力**を固定していた。文字列一致だけの assertion だったため、このバグを通していた。正しい挙動に更新したうえで、回帰テストを追加：

- 非 `id` 名の正規化 + dict キー保持の契約
- `id` 名のときは不変であること
- 衝突時に例外を投げること

## 検証

**`swiftc -typecheck`**（golden テストは文字列一致だけなのでこの種のバグを通す。実コンパイルで確認した）
- 実物の `AppIntentsBridge` ソースからビルドしたモジュールに対して検証。`app_intents` は Flutter に依存するため、生成コードが実際に使う唯一のシンボル `AppIntentsPlugin.getCached(forKey:)` のみ実シグネチャどおりにスタブ化
- `id` / `teamId` / `uuid` / `recordKey` × plain / full（enumerable + indexed + persistedCacheKey + `@Property` + entity パラメータ）の **8通りすべて exit 0**
- 修正前の同一入力は上記3エラー
- rebase 後（#99 込みの main 上）に再実行して同じく 8/8 green

**後方互換**
- フィールド名が `id` の既存エンティティは、修正前後で出力が**バイト単位で同一**
- Example App の生成 Swift も差分ゼロ

**テスト / 静的解析**
- codegen 387 / annotations 20 / app_intents 64 / app 1 — すべて green
- `dart analyze` 全パッケージ issue なし、`dart format` 差分なし

環境に Xcode 27 beta がないため Xcode 26.6（iOS 26.5 SDK）で検証したが、本件は stable SDK の iOS 17 `Identifiable` 準拠の問題で WWDC26 API は不要。

## 補足
- Kotlin ジェネレータは `@AppFunctionSerializable` の data class で `Identifiable` 相当の制約がないため、Dart フィールド名のままで正しい（変更なし）
- `docs/usage.md` 等の例は元々 `id` 命名のため記述の誤りはなく、変更していない
- `_swiftPropertyName` は両ジェネレータで別々の private helper のまま（クラスが別で、Widget 側は `(role, prop)` シグネチャ）。共通化は本 PR のスコープ外とし、CLAUDE.md に両者が同じ契約である旨を明記した

🤖 Generated with [Claude Code](https://claude.com/claude-code)